### PR TITLE
Validate provided keys

### DIFF
--- a/pysesame3/auth.py
+++ b/pysesame3/auth.py
@@ -10,6 +10,9 @@ class WebAPIAuth(requests.auth.AuthBase):
         """
         self._apikey = apikey
 
+        if len(self._apikey) != 40:
+            raise ValueError("Invalid API Key - length should be 40.")
+
     def __call__(self, r):
         r.headers["x-api-key"] = self._apikey
         return r

--- a/pysesame3/device.py
+++ b/pysesame3/device.py
@@ -127,7 +127,9 @@ class SesameLocker(CHDevices):
             ValueError: If `key` is invalid.
         """
         if not isinstance(key, str):
-            raise ValueError("Invalid SecretKey")
+            raise ValueError("Invalid SecretKey - should be string.")
+        if len(key) != 32:
+            raise ValueError("Invalid SecretKey - length should be 32.")
         self._secretKey = key
 
     def setSesame2PublicKey(self, key: str) -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+"""Tests for `pysesame3` package."""
+
+import pytest
+
+from pysesame3.auth import WebAPIAuth
+
+
+def test_WebAPIAuth_raises_exception_on_missing_arguments():
+    with pytest.raises(TypeError):
+        WebAPIAuth()
+
+
+def test_WebAPIAuth_raises_exception_on_invalid_apikey():
+    with pytest.raises(ValueError) as excinfo:
+        WebAPIAuth(apikey="thisisfake")
+    assert "length should be 40" in str(excinfo.value)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -5,6 +5,7 @@
 import uuid
 
 import pytest
+
 from pysesame3.auth import WebAPIAuth
 from pysesame3.device import CHDevices, SesameLocker
 from pysesame3.helper import CHProductModel
@@ -12,7 +13,7 @@ from pysesame3.helper import CHProductModel
 
 @pytest.fixture(autouse=True)
 def cl():
-    yield WebAPIAuth(apikey="FAKEAPIKEY")
+    yield WebAPIAuth(apikey="FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE")
 
 
 class TestCHDevices:
@@ -77,15 +78,20 @@ class TestSesameLocker:
     def test_SesameLocker_secretKey_raises_exception_on_invalid_value(self):
         d = SesameLocker(cl)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as excinfo:
             d.setSecretKey(123)
+        assert "should be string" in str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            d.setSecretKey("FAKE")
+        assert "length should be 32" in str(excinfo.value)
 
     def test_CHDevices_secretKey(self):
         d = SesameLocker(cl)
 
         assert d.getSecretKey() is None
 
-        secret = "TestSecret"
+        secret = "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE"
 
         assert d.setSecretKey(secret) is None
         assert d.getSecretKey() == secret
@@ -115,7 +121,7 @@ class TestSesameLocker:
         test_model = CHProductModel.SS2
         d.setProductModel(test_model)
 
-        secret = "TestSecret"
+        secret = "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE"
         d.setSecretKey(secret)
 
         pubkey = "TestPubKey"
@@ -123,5 +129,5 @@ class TestSesameLocker:
 
         assert (
             str(d)
-            == "SesameLocker(deviceUUID=42918AD1-8154-4AFF-BD1F-F0CDE88A8DE1, deviceModel=CHProductModel.SS2, secretKey=TestSecret, sesame2PublicKey=TestPubKey)"
+            == "SesameLocker(deviceUUID=42918AD1-8154-4AFF-BD1F-F0CDE88A8DE1, deviceModel=CHProductModel.SS2, secretKey=FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE, sesame2PublicKey=TestPubKey)"
         )

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -4,6 +4,7 @@
 
 import pytest
 import requests_mock
+
 from pysesame3.auth import WebAPIAuth
 from pysesame3.lock import CHSesame2, CHSesame2ShadowStatus
 
@@ -35,17 +36,32 @@ def mock_requests():
 
 @pytest.fixture()
 def mock_cloud():
-    cl = WebAPIAuth(apikey="FAKEAPIKEY")
+    cl = WebAPIAuth(apikey="FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE")
     yield cl
 
 
 class TestCHSesame2Broken:
-    def test_CHSesame2_raises_exception_on_invalid_arguments(self):
+    def test_CHSesame2_raises_exception_on_missing_arguments(self):
         with pytest.raises(TypeError):
             CHSesame2()
 
         with pytest.raises(TypeError):
             CHSesame2(mock_cloud)
+
+    def test_CHSesame2_raises_exception_on_invalid_arguments(self):
+        with pytest.raises(ValueError):
+            key = {
+                "device_uuid": "FAKEUUID",
+                "secret_key": "0b3e5f1665e143b59180c915fa4b06d9",
+            }
+            CHSesame2(mock_cloud, **key)
+
+        with pytest.raises(ValueError):
+            key = {
+                "device_uuid": "126D3D66-9222-4E5A-BCDE-0C6629D48D43",
+                "secret_key": "FAKE_SECRET_KEY",
+            }
+            CHSesame2(mock_cloud, **key)
 
 
 class TestCHSesame2:


### PR DESCRIPTION
The API key should be 40 characters for now, and the secret key should be 32 characters.
Just to make sure, we'll do a quick check.