### PR TITLE
Hide secret keys from string rep of a key

### DIFF
--- a/pysesame3/device.py
+++ b/pysesame3/device.py
@@ -151,4 +151,4 @@ class SesameLocker(CHDevices):
         Returns:
             str: The string representation of the object.
         """
-        return f"SesameLocker(deviceUUID={self.getDeviceUUID()}, deviceModel={self.productModel}, secretKey={self.getSecretKey()}, sesame2PublicKey={self.getSesame2PublicKey()})"
+        return f"SesameLocker(deviceUUID={self.getDeviceUUID()}, deviceModel={self.productModel}, sesame2PublicKey={self.getSesame2PublicKey()})"

--- a/pysesame3/lock.py
+++ b/pysesame3/lock.py
@@ -115,4 +115,4 @@ class CHSesame2(SesameLocker):
         Returns:
             str: The string representation of the object.
         """
-        return f"CHSesame2(deviceUUID={self.getDeviceUUID()}, deviceModel={self.productModel}, secretKey={self.getSecretKey()}, sesame2PublicKey={self.getSesame2PublicKey()}, mechStatus={self.mechStatus})"
+        return f"CHSesame2(deviceUUID={self.getDeviceUUID()}, deviceModel={self.productModel}, sesame2PublicKey={self.getSesame2PublicKey()}, mechStatus={self.mechStatus})"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -129,5 +129,5 @@ class TestSesameLocker:
 
         assert (
             str(d)
-            == "SesameLocker(deviceUUID=42918AD1-8154-4AFF-BD1F-F0CDE88A8DE1, deviceModel=CHProductModel.SS2, secretKey=FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE, sesame2PublicKey=TestPubKey)"
+            == "SesameLocker(deviceUUID=42918AD1-8154-4AFF-BD1F-F0CDE88A8DE1, deviceModel=CHProductModel.SS2, sesame2PublicKey=TestPubKey)"
         )

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -87,7 +87,7 @@ class TestCHSesame2:
         )
         assert (
             str(self.key_locked)
-            == "CHSesame2(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=None, secretKey=0b3e5f1665e143b59180c915fa4b06d9, sesame2PublicKey=None, mechStatus=CHSesame2MechStatus(Battery=67% (5.87V), isInLockRange=True, isInUnlockRange=False, Position=11))"
+            == "CHSesame2(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=None, sesame2PublicKey=None, mechStatus=CHSesame2MechStatus(Battery=67% (5.87V), isInLockRange=True, isInUnlockRange=False, Position=11))"
         )
 
     def test_CHSesame2_setDeviceShadowStatus_toggle(self):


### PR DESCRIPTION
In order to manage accidental / unintended `secret_key` exposures.