### PR TITLE
Use an auto-generated release note for publishing a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create github release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
There are no release notes shown for all releases so far. This has been fixed in [this PR](https://github.com/softprops/action-gh-release/pull/85).