### PR TITLE
Do not limit the length of the AES-MAC (`sign`) value

### DIFF
--- a/pysesame3/cloud.py
+++ b/pysesame3/cloud.py
@@ -84,7 +84,7 @@ class SesameCloud:
         bArr.append(((j2 >> 16) & 65535) & 0xFF)
         bArr.append(((j2 >> 24) & 65535) & 0xFF)
         secret = bytes.fromhex(self._device.getSecretKey())
-        cobj = CMAC.new(secret, ciphermod=AES, mac_len=4)
+        cobj = CMAC.new(secret, ciphermod=AES)
         cobj.update(bArr)
         sign = cobj.hexdigest()
 


### PR DESCRIPTION
Length of the authentication tag was 4 bytes in the SDK, and that was what I was trying to implement.
OTOH, [the sample code in the official API doc](https://doc.candyhouse.co/ja/SesameAPI#%E3%82%B3%E3%83%BC%E3%83%89-%E7%94%A8%E4%BE%8B) sends a full-length MAC tag.

The 4 bytes `sign` actually works even in the Web API at this moment, but we should make sure that the same request body as the sample code is generated just in case.