### PR TITLE
[Breaking Change] Default key tag is changed to `pysesame3` from `API`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,7 +26,17 @@ def main():
     print((str(device.mechStatus)))
     # => CHSesame2MechStatus(Battery=100% (6.08V), isInLockRange=True, isInUnlockRange=False, Position=-10)
 
-    device.unlock()
+    """
+    The `history_tag` can be set when locking and unlocking (default = `pysesame3`).
+    This tag will be stored in the history as the name (tag) of the key that unlocked or locked the door.
+    It will be more understandable when auditing the key operation using APIs and the apps.
+    """
+    device.unlock(history_tag="My Script")
+
+    """
+    `mechStatus` always gets the latest status from the cloud.
+    Therefore, **just after** locking or unlocking the door, the status such as `isInLockRange` will not be updated.
+    """
     time.sleep(5)
 
     print((str(device.mechStatus)))

--- a/pysesame3/cloud.py
+++ b/pysesame3/cloud.py
@@ -67,11 +67,12 @@ class SesameCloud:
 
         return CHSesame2MechStatus(dictdata=r_json)
 
-    def sendCmd(self, cmd: CHSesame2CMD) -> bool:
+    def sendCmd(self, cmd: CHSesame2CMD, history_tag: str = "pysesame3") -> bool:
         """Sends a locking/unlocking command.
 
         Args:
             cmd (CHSesame2CMD): Lock, Unlock and Toggle.
+            history_tag (CHSesame2CMD): The key tag to sent when locking and unlocking.
 
         Returns:
             bool: `True` if success, `False` if not.
@@ -90,7 +91,7 @@ class SesameCloud:
 
         payload = {
             "cmd": int(cmd),
-            "history": base64.b64encode("API".encode()).decode(),
+            "history": base64.b64encode(history_tag.encode()).decode(),
             "sign": sign,
         }
 

--- a/pysesame3/lock.py
+++ b/pysesame3/lock.py
@@ -76,38 +76,47 @@ class CHSesame2(SesameLocker):
             raise ValueError("Invalid CHSesame2ShadowStatus")
         self._deviceShadowStatus = status
 
-    def lock(self) -> bool:
+    def lock(self, history_tag: str = "pysesame3") -> bool:
         """Locking.
+
+        Args:
+            history_tag (str): The key tag to sent when locking and unlocking. Defaults to `pysesame3`.
 
         Returns:
             bool: `True` if it is successfully locked, `False` if not.
         """
-        result = SesameCloud(self).sendCmd(CHSesame2CMD.LOCK)
+        result = SesameCloud(self).sendCmd(CHSesame2CMD.LOCK, history_tag)
         if result:
             self.setDeviceShadowStatus(CHSesame2ShadowStatus.LockedWm)
         return result
 
-    def unlock(self) -> bool:
+    def unlock(self, history_tag: str = "pysesame3") -> bool:
         """Unlocking.
+
+        Args:
+            history_tag (str): The key tag to sent when locking and unlocking. Defaults to `pysesame3`.
 
         Returns:
             bool: `True` if it is successfully unlocked, `False` if not.
         """
-        result = SesameCloud(self).sendCmd(CHSesame2CMD.UNLOCK)
+        result = SesameCloud(self).sendCmd(CHSesame2CMD.UNLOCK, history_tag)
         if result:
             self.setDeviceShadowStatus(CHSesame2ShadowStatus.UnlockedWm)
         return result
 
-    def toggle(self) -> bool:
+    def toggle(self, history_tag: str = "pysesame3") -> bool:
         """Toggle.
+
+        Args:
+            history_tag (str): The key tag to sent when locking and unlocking. Defaults to `pysesame3`.
 
         Returns:
             bool: `True` if it is successfully toggled, `False` if not.
         """
         if self.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm:
-            return self.unlock()
+            return self.unlock(history_tag)
         elif self.getDeviceShadowStatus() == CHSesame2ShadowStatus.UnlockedWm:
-            return self.lock()
+            return self.lock(history_tag)
 
     def __str__(self) -> str:
         """Return a string representation of an object.


### PR DESCRIPTION
This commit allows users to set their own key tags.
Key tags will be stored in the history as the name of the key that unlocked or locked the door.
It will be more understandable when auditing the key operation using APIs and the apps.