### PR TITLE
`setDeviceShadowStatus` when acquiring mechanical state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poetry tox tox-gh-actions
+          pip install tox tox-gh-actions
 
       - name: Test with tox
         run:

--- a/pysesame3/lock.py
+++ b/pysesame3/lock.py
@@ -41,10 +41,8 @@ class CHSesame2(SesameLocker):
         self.setDeviceUUID(device_uuid)
         self.setSecretKey(secret_key)
 
-        if self.mechStatus.isInLockRange():
-            self._deviceShadowStatus = CHSesame2ShadowStatus.LockedWm
-        else:
-            self._deviceShadowStatus = CHSesame2ShadowStatus.UnlockedWm
+        # Initial sync of `self._deviceShadowStatus`
+        self.mechStatus
 
     @property
     def mechStatus(self) -> CHSesame2MechStatus:
@@ -53,10 +51,18 @@ class CHSesame2(SesameLocker):
         Returns:
             CHSesame2MechStatus: Current mechanical status of the device.
         """
-        return SesameCloud(self).getMechStatus()
+        status = SesameCloud(self).getMechStatus()
+
+        if status.isInLockRange():
+            self.setDeviceShadowStatus(CHSesame2ShadowStatus.LockedWm)
+        else:
+            self.setDeviceShadowStatus(CHSesame2ShadowStatus.UnlockedWm)
+
+        return status
 
     def getDeviceShadowStatus(self) -> CHSesame2ShadowStatus:
-        """Returns a shadow status of a device.
+        """Returns a cached shadow status of a device.
+        In order to refresh the shadow, run `mechStatus`.
 
         Returns:
             CHSesame2ShadowStatus: Shadow (assumed) status of the device.

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
     3.7: py37
 
 [testenv:lint]
-whitelist_externals = poetry
+deps = poetry
 commands =
     poetry install -E doc
     poetry run isort pysesame3
@@ -20,11 +20,11 @@ commands =
     poetry run twine check dist/*
 
 [testenv]
-whitelist_externals = poetry
 passenv = *
 setenv =
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = ignore
+deps = poetry
 commands =
     poetry install
     poetry run pytest -s --cov=pysesame3 --cov-append --cov-report=xml --cov-report term-missing tests


### PR DESCRIPTION
The state of the lock could be changed in ways other than the API, which can lead to a mismatch between the real state and the device shadow.
For instance, `toggle` is looking at a shadow, this mismatch may prevent it from controlling a key correctly.
This commit is aimed to update a shadow a bit more aggressively.