### PR TITLE
Support for setting the callback for MechStatus updates

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -8,3 +8,5 @@ coverage:
       default:
         enabled: no
         if_not_found: success
+    project:
+        informational: true

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,9 +4,22 @@
 import time
 from pprint import pprint
 
-from pysesame3.auth import WebAPIAuth, CognitoAuth
-from pysesame3.lock import CHSesame2
+from pysesame3.auth import CognitoAuth, WebAPIAuth
 from pysesame3.cloud import SesameCloud
+from pysesame3.helper import CHSesame2MechStatus
+from pysesame3.lock import CHSesame2
+
+
+def callback(device: CHSesame2, status: CHSesame2MechStatus):
+    print("=" * 10)
+    print("mechStatus is updated!")
+    print("UUID: {}".format(device.getDeviceUUID()))
+    print("Battery: {}%".format(status.getBatteryPrecentage()))
+    print("Battery: {:.2f}V".format(status.getBatteryVoltage()))
+    print("isInLockRange: {}".format(status.isInLockRange()))
+    print("isInUnlockRange: {}".format(status.isInUnlockRange()))
+    print("Position: {}".format(status.getPosition()))
+    print("=" * 10)
 
 
 def main():
@@ -63,7 +76,7 @@ def main():
     The mobile app shows the status of the key in almost real time.
     In the same way, you can **subscribe** to `mechStatus`.
     """
-    device.subscribeMechStatus()
+    device.subscribeMechStatus(callback)
 
     print("=" * 10)
     print("[History]")
@@ -83,10 +96,6 @@ def main():
             device.toggle(history_tag="My Script")
         else:
             continue
-
-        time.sleep(5)
-        print((str(device.mechStatus)))
-        # => CHSesame2MechStatus(Battery=100% (6.09V), isInLockRange=True, isInUnlockRange=False, Position=25)
 
 
 if __name__ == "__main__":

--- a/pysesame3/lock.py
+++ b/pysesame3/lock.py
@@ -73,11 +73,11 @@ class CHSesame2(SesameLocker):
 
         return status
 
-    def _iot_shadow_callback(self, client, userdata, message) -> None:
-        """Example Callback for updated shadows.
+    def _iot_shadow_callback(self, client, userdata, message: dict) -> None:
+        """Callback for updated shadows.
 
         Args:
-            message ([type]): The device shadow
+            message (dict): The device shadow
         """
         shadow = json.loads(message.payload)
         status = CHSesame2MechStatus(rawdata=shadow["state"]["reported"]["mechst"])

--- a/pysesame3/lock.py
+++ b/pysesame3/lock.py
@@ -106,7 +106,10 @@ class CHSesame2(SesameLocker):
         if self.authenticator.login_method != AuthType.SDK:
             raise NotImplementedError("This feature is not suppoted by the Web API.")
 
-        self._callback = callback
+        if callable(callback) or callback is None:
+            self._callback = callback
+        else:
+            raise TypeError("callback should be callable.")
 
         if self._iot_client is not None:
             raise RuntimeError(

--- a/pysesame3/lock.py
+++ b/pysesame3/lock.py
@@ -51,6 +51,8 @@ class CHSesame2(SesameLocker):
 
         self.setDeviceUUID(device_uuid)
         self.setSecretKey(secret_key)
+        self._iot_client = None
+        self._callback = None
 
         # Initial sync of `self._deviceShadowStatus`
         self.mechStatus
@@ -84,11 +86,16 @@ class CHSesame2(SesameLocker):
         else:
             self.setDeviceShadowStatus(CHSesame2ShadowStatus.UnlockedWm)
 
-    def subscribeMechStatus(self, callback: Callable[..., None] = None) -> bool:
+        if self._callback is not None and callable(self._callback):
+            self._callback(self, status)
+
+    def subscribeMechStatus(
+        self, callback: Callable[[CHSesame2, CHSesame2MechStatus], None] = None
+    ) -> bool:
         """Subscribes to a topic at AWS IoT
 
         Args:
-            callback (Callable[..., None], optional): The registered callback will be executed once an update is delivered. Defaults to `_iot_shadow_callback`.
+            callback (Callable[[CHSesame2, CHSesame2MechStatus], None], optional): The registered callback will be executed once an update is delivered. Defaults to `None`.
 
         Raises:
             NotImplementedError: If the authenticator is not `AuthType.SDK`.
@@ -99,21 +106,30 @@ class CHSesame2(SesameLocker):
         if self.authenticator.login_method != AuthType.SDK:
             raise NotImplementedError("This feature is not suppoted by the Web API.")
 
-        callback = callback or self._iot_shadow_callback
+        self._callback = callback
+
+        if self._iot_client is not None:
+            raise RuntimeError(
+                "subscribeMechStatus is already called for the device, update the callback anyway."
+            )
 
         (access_key_id, secret_key, session_token) = self.authenticator.authenticate()
 
-        c = AWSIoTMQTTClient(self.authenticator.client_id, useWebsocket=True)
-        c.configureEndpoint(IOT_EP, 443)
-        c.configureCredentials(certifi.where())
-        c.configureIAMCredentials(access_key_id, secret_key, session_token)
-        c.connect()
-        c.subscribe(
+        self._iot_client = AWSIoTMQTTClient(
+            self.authenticator.client_id, useWebsocket=True
+        )
+        self._iot_client.configureEndpoint(IOT_EP, 443)
+        self._iot_client.configureCredentials(certifi.where())
+        self._iot_client.configureIAMCredentials(
+            access_key_id, secret_key, session_token
+        )
+        self._iot_client.connect()
+        self._iot_client.subscribe(
             "$aws/things/sesame2/shadow/name/{}/update/accepted".format(
                 self.getDeviceUUID()
             ),
             1,
-            callback,
+            self._iot_shadow_callback,
         )
 
     @property

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -125,6 +125,13 @@ class TestCHSesame2:
             == "CHSesame2(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=None, sesame2PublicKey=None, mechStatus=CHSesame2MechStatus(Battery=67% (5.87V), isInLockRange=True, isInUnlockRange=False, Position=11))"
         )
 
+    def test_CHSesame2_subscribeMechStatus_raises_exception_with_WebAPI(self):
+        def _callback(*_):
+            return True
+
+        with pytest.raises(NotImplementedError):
+            self.key_locked.subscribeMechStatus(_callback)
+
     def test_CHSesame2_getDeviceShadowStatus(self):
         assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
         assert (
@@ -214,6 +221,14 @@ class TestCHSesame2Cognito:
             str(self.key_locked)
             == "CHSesame2(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=None, sesame2PublicKey=None, mechStatus=CHSesame2MechStatus(Battery=100% (6.11V), isInLockRange=True, isInUnlockRange=False, Position=29))"
         )
+
+    def test_CHSesame2_subscribeMechStatus_raises_exception_on_invalid_arguments(self):
+        with pytest.raises(TypeError):
+            self.key_locked.subscribeMechStatus("NOT-CALLABLE")
+
+    def test_CHSesame2_subscribeMechStatus(self):
+        # TODO: Make tests using moto
+        pass
 
     def test_CHSesame2_getDeviceShadowStatus(self):
         assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm


### PR DESCRIPTION
This PR allows the user to set the callback to be called when the MechStatus is updated.
Callbacks must accept two inputs. The first will be a device object itself and the second will be the latest MechStatus.

Example usage is updated accordingly.