### PR TITLE
Ensure we have the latest pip version in build environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        python-versions: [3.7, 3.8, 3.9]
+        python-versions: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,5 +45,6 @@ commands =
 skip_install = True
 passenv = TERM
 deps = pre-commit
+commands_pre =
 commands =
    pre-commit run [] --all-files --show-diff-on-failure --hook-stage=manual

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ python =
 [testenv]
 passenv = CI
 deps = poetry
+commands_pre = poetry run python -m pip install pip -U
 commands =
    poetry install --no-root -v -E cognito
    poetry run pytest []


### PR DESCRIPTION
I noticed that our CI with macOS environment **occasionally** fails.
This PR fixes it by ensuring that we use the latest version of `pip` in build envs.

According to [the log](https://github.com/mochipon/pysesame3/runs/2947707282), it seems that `tenacity` which is vendored in `pip` fails to importing `tornado` modules. The issues here seems to be solved at https://github.com/pypa/pip/pull/10029, and the latest release (21.1.3) contains it.