### PR TITLE
Move from AWS IoT Device SDK v1 to v2

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -9,4 +9,5 @@ coverage:
         enabled: no
         if_not_found: success
     project:
+      default:
         informational: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,3 +10,4 @@ python:
       path: .
       extra_requirements:
         - doc
+        - cognito

--- a/LICENSE
+++ b/LICENSE
@@ -45,3 +45,210 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+## AWS IoT Device SDK v2 for Python
+https://github.com/aws/aws-iot-device-sdk-python-v2
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ typing-extensions = { version = "^3.10.0.0", python = "<3.8" }
 pycryptodome = { version = "^3.10.1" }
 requests = { version = "^2.25.1" }
 
-AWSIoTPythonSDK = { version = "^1.4.9", optional = true }
+awsiotsdk = { version = "^1.6.1", optional = true }
 boto3 = { version = "^1.17.94", optional = true }
 certifi = { version = "*", optional = true }
 requests-aws4auth = { version = "^1.1.1", optional = true }
@@ -47,6 +47,7 @@ mkdocs-include-markdown-plugin = { version = "^3.1.3", optional = true }
 mkdocs-material = { version = "^7.1.8", optional = true }
 
 [tool.poetry.dev-dependencies]
+asynctest = "^0.13.0"
 bump2version = "^1.0.1"
 moto = {extras = ["cognito-identity"], version = "^2.0.9"}
 pre-commit = "^2.13.0"
@@ -64,7 +65,7 @@ doc = [
     "mkdocs-material"
 ]
 cognito = [
-    "AWSIoTPythonSDK",
+    "awsiotsdk",
     "boto3",
     "certifi",
     "requests-aws4auth"

--- a/pysesame3/auth.py
+++ b/pysesame3/auth.py
@@ -5,7 +5,7 @@ try:
     import boto3
     from awscrt import auth
     from requests_aws4auth import AWS4Auth
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     pass
 import requests
 
@@ -16,7 +16,7 @@ from .helper import RegexHelper
 if TYPE_CHECKING:
     try:
         from awscrt import mqtt
-    except ImportError: # pragma: no cover
+    except ImportError:  # pragma: no cover
         pass
 
 
@@ -75,7 +75,9 @@ class CognitoAuth:
         if len(apikey) != 40:
             raise ValueError("Invalid API Key - length should be 40.")
 
-        if "awsiot" not in sys.modules or "certifi" not in sys.modules: # pragma: no cover
+        if (
+            "awsiot" not in sys.modules or "certifi" not in sys.modules
+        ):  # pragma: no cover
             raise RuntimeError(
                 "Failed to load awsiotsdk or certifi. Did you run `pip install pysesame3[cognito]`?"
             )

--- a/pysesame3/auth.py
+++ b/pysesame3/auth.py
@@ -1,14 +1,24 @@
 import sys
+from typing import TYPE_CHECKING, Tuple
 
 try:
     import boto3
+    from awscrt import auth
     from requests_aws4auth import AWS4Auth
 except ImportError:
     # Optional deps
     pass
 import requests
 
+from .cloud import AWSIoT, SesameCloud
 from .const import IOT_EP, AuthType
+from .helper import RegexHelper
+
+if TYPE_CHECKING:
+    try:
+        from awscrt import mqtt
+    except ImportError:
+        pass
 
 
 class WebAPIAuth(requests.auth.AuthBase):
@@ -18,48 +28,97 @@ class WebAPIAuth(requests.auth.AuthBase):
         Args:
             apikey (str): API Key
         """
-        self._apikey = apikey
-
-        if len(self._apikey) != 40:
+        if len(apikey) != 40:
             raise ValueError("Invalid API Key - length should be 40.")
 
+        self._apikey = apikey
+        self._sesame_cloud = SesameCloud(self)
+
     @property
-    def login_method(self):
+    def login_method(self) -> AuthType:
+        """Return a login method of this authentication.
+
+        Returns:
+            AuthType: `WebAPI` or `SDK`
+        """
         return AuthType.WebAPI
 
-    def __call__(self, r):
-        r.headers["x-api-key"] = self._apikey
-        return r
+    @property
+    def sesame_cloud(self) -> SesameCloud:
+        return self._sesame_cloud
+
+    @property
+    def aws_iot(self):
+        raise NotImplementedError("Not supported with WebAPI.")
+
+    def __call__(
+        self, request: requests.models.PreparedRequest
+    ) -> requests.models.PreparedRequest:
+        """Function to transform HTTP request with `requests.Request`.
+
+        This function aims to be called during request setup.
+
+        Args:
+            request (requests.models.PreparedRequest): The HTTP request to be transformed.
+        """
+        request.headers["x-api-key"] = self._apikey
+        return request
 
 
 class CognitoAuth:
     def __init__(self, apikey: str, client_id: str):
-        """Generic Implementation for Web API Authentication.
+        """Generic Implementation for Cognito Authentication.
 
         Args:
             apikey (str): API Key
             client_id (str): Client ID
         """
+        if len(apikey) != 40:
+            raise ValueError("Invalid API Key - length should be 40.")
+
+        if "awsiot" not in sys.modules or "certifi" not in sys.modules:
+            raise RuntimeError(
+                "Failed to load awsiotsdk or certifi. Did you run `pip install pysesame3[cognito]`?"
+            )
+
         self._apikey = apikey
         self._client_id = client_id
 
-        if len(self._apikey) != 40:
-            raise ValueError("Invalid API Key - length should be 40.")
-
-        if "AWSIoTPythonSDK" not in sys.modules or "certifi" not in sys.modules:
-            raise RuntimeError(
-                "Failed to load AWSIoTPythonSDK or certifi. Did you run `pip install pysesame3[cognito]`?"
-            )
+        self._sesame_cloud = SesameCloud(self)
+        self._aws_iot = AWSIoT(self)
 
     @property
     def login_method(self) -> AuthType:
+        """Return a login method of this authentication.
+
+        Returns:
+            AuthType: `WebAPI` or `SDK`
+        """
         return AuthType.SDK
 
     @property
+    def sesame_cloud(self) -> SesameCloud:
+        return self._sesame_cloud
+
+    @property
+    def aws_iot(self) -> AWSIoT:
+        return self._aws_iot
+
+    @property
     def client_id(self) -> str:
+        """Return a client id.
+
+        Returns:
+            str: Client ID
+        """
         return self._client_id
 
-    def authenticate(self):
+    def authenticate(self) -> Tuple[str, str, str]:
+        """Authenticate and get a credential from AWS Cognito.
+
+        Returns:
+            Tuple[str, str, str]: `access_key_id`, `secret_key` and `session_token`
+        """
         region_name = self.client_id.split(":")[0]
 
         cognitoIdentityClient = boto3.client(
@@ -79,22 +138,75 @@ class CognitoAuth:
 
         return (access_key_id, secret_key, session_token)
 
-    def __call__(self, r):
+    def iot_websocket_handshake_transform(
+        self, transform_args: "mqtt.WebsocketHandshakeTransformArgs"
+    ) -> None:
+        """Function to transform websocket handshake request within `awscrt.mqtt.Connection`.
+
+        This function aims to be called each time a websocket connection is attempted.
+
+        Args:
+            transform_args (mqtt.WebsocketHandshakeTransformArgs): Contains HTTP request to be transformed. The function calls `transform_args.done()` when complete.
+        """
+        try:
+            (
+                access_key_id,
+                secret_key,
+                session_token,
+            ) = self.authenticate()
+
+            cred_provider = auth.AwsCredentialsProvider.new_static(
+                access_key_id=access_key_id,
+                secret_access_key=secret_key,
+                session_token=session_token,
+            )
+
+            signing_config = auth.AwsSigningConfig(
+                algorithm=auth.AwsSigningAlgorithm.V4,
+                signature_type=auth.AwsSignatureType.HTTP_REQUEST_QUERY_PARAMS,
+                credentials_provider=cred_provider,
+                region=RegexHelper.get_aws_region(IOT_EP),
+                service="iotdevicegateway",
+                omit_session_token=True,  # IoT is weird and does not sign X-Amz-Security-Token
+            )
+
+            signing_future = auth.aws_sign_request(
+                transform_args.http_request, signing_config
+            )
+            signing_future.add_done_callback(
+                lambda x: transform_args.set_done(x.exception())
+            )
+        except Exception as e:
+            transform_args.set_done(e)
+
+    def __call__(
+        self, request: requests.models.PreparedRequest
+    ) -> requests.models.PreparedRequest:
+        """Function to transform HTTP request with `requests.Request`.
+
+        This function aims to be called during request setup.
+
+        Args:
+            request (requests.models.PreparedRequest): The HTTP request to be transformed.
+        """
+        if request.url is None:
+            raise TypeError("Failed to retrive HTTP URL to send the request to.")
+
         (access_key_id, secret_key, session_token) = self.authenticate()
 
-        if IOT_EP in r.url:
+        if IOT_EP in request.url:
             service = "iotdata"
         else:
-            r.headers["x-api-key"] = self._apikey
+            request.headers["x-api-key"] = self._apikey
             service = "execute-api"
 
         auth = AWS4Auth(
             access_key_id,
             secret_key,
-            "ap-northeast-1",
+            RegexHelper.get_aws_region(request.url),
             service,
             session_token=session_token,
         )
-        r = auth(r)
+        request = auth(request)
 
-        return r
+        return request

--- a/pysesame3/auth.py
+++ b/pysesame3/auth.py
@@ -5,8 +5,7 @@ try:
     import boto3
     from awscrt import auth
     from requests_aws4auth import AWS4Auth
-except ImportError:
-    # Optional deps
+except ImportError: # pragma: no cover
     pass
 import requests
 
@@ -17,7 +16,7 @@ from .helper import RegexHelper
 if TYPE_CHECKING:
     try:
         from awscrt import mqtt
-    except ImportError:
+    except ImportError: # pragma: no cover
         pass
 
 
@@ -76,7 +75,7 @@ class CognitoAuth:
         if len(apikey) != 40:
             raise ValueError("Invalid API Key - length should be 40.")
 
-        if "awsiot" not in sys.modules or "certifi" not in sys.modules:
+        if "awsiot" not in sys.modules or "certifi" not in sys.modules: # pragma: no cover
             raise RuntimeError(
                 "Failed to load awsiotsdk or certifi. Did you run `pip install pysesame3[cognito]`?"
             )

--- a/pysesame3/chsesame2.py
+++ b/pysesame3/chsesame2.py
@@ -4,8 +4,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 try:
     from awscrt import mqtt
-except ImportError:
-    # Optional deps
+except ImportError: # pragma: no cover
     pass
 
 from pysesame3.auth import CognitoAuth

--- a/pysesame3/chsesame2.py
+++ b/pysesame3/chsesame2.py
@@ -3,15 +3,12 @@ from enum import Enum, IntEnum, auto
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 try:
-    import certifi
-    from AWSIoTPythonSDK.MQTTLib import AWSIoTMQTTClient
+    from awscrt import mqtt
 except ImportError:
     # Optional deps
     pass
 
 from pysesame3.auth import CognitoAuth
-from pysesame3.cloud import SesameCloud
-from pysesame3.const import IOT_EP
 from pysesame3.device import SesameLocker
 from pysesame3.helper import CHSesame2MechStatus
 
@@ -50,7 +47,6 @@ class CHSesame2(SesameLocker):
 
         self.setDeviceUUID(device_uuid)
         self.setSecretKey(secret_key)
-        self._iot_client: Optional[AWSIoTMQTTClient] = None
         self._callback: Optional[
             Callable[[CHSesame2, CHSesame2MechStatus], None]
         ] = None
@@ -65,7 +61,7 @@ class CHSesame2(SesameLocker):
         Returns:
             CHSesame2MechStatus: Current mechanical status of the device.
         """
-        status = SesameCloud(self).getMechStatus()
+        status = self.authenticator.sesame_cloud.getMechStatus(self)
 
         if status.isInLockRange():
             self.setDeviceShadowStatus(CHSesame2ShadowStatus.LockedWm)
@@ -74,14 +70,14 @@ class CHSesame2(SesameLocker):
 
         return status
 
-    def _iot_shadow_callback(self, client, userdata, message) -> None:  # type: ignore
+    def _iot_shadow_callback(self, topic: str, payload: bytes, *_):
         """Callback for updated shadows.
 
         Args:
             message (dict): The device shadow
         """
         try:
-            shadow = json.loads(message.payload)
+            shadow = json.loads(payload.decode("utf-8"))
             status = CHSesame2MechStatus(rawdata=shadow["state"]["reported"]["mechst"])
 
             original_status = self.getDeviceShadowStatus()
@@ -101,22 +97,6 @@ class CHSesame2(SesameLocker):
         except Exception as err:  # noqa: F841
             # TODO: handle exceptions correctly
             pass
-
-    def _iot_on_offline(self) -> None:
-        """Callback that gets called when the AWS IoT client is offline.
-
-        This is intended to update the credentials before reconnecting.
-        """
-        if not isinstance(self.authenticator, CognitoAuth):
-            raise NotImplementedError("This feature is not suppoted by the Web API.")
-        if self._iot_client is None:
-            raise RuntimeError("subscribeMechStatus is not called yet.")
-
-        (access_key_id, secret_key, session_token) = self.authenticator.authenticate()
-
-        self._iot_client.configureIAMCredentials(
-            access_key_id, secret_key, session_token
-        )
 
     def subscribeMechStatus(
         self,
@@ -138,30 +118,17 @@ class CHSesame2(SesameLocker):
         else:
             raise TypeError("callback should be callable.")
 
-        if self._iot_client is not None:
-            raise RuntimeError(
-                "subscribeMechStatus is already called for the device, update the callback anyway."
-            )
+        aws_iot = self.authenticator.aws_iot
+        aws_iot.connect()
 
-        (access_key_id, secret_key, session_token) = self.authenticator.authenticate()
-
-        self._iot_client = AWSIoTMQTTClient(
-            self.authenticator.client_id, useWebsocket=True
-        )
-        self._iot_client.configureEndpoint(IOT_EP, 443)
-        self._iot_client.configureCredentials(certifi.where())
-        self._iot_client.configureIAMCredentials(
-            access_key_id, secret_key, session_token
-        )
-        self._iot_client.onOffline = self._iot_on_offline
-        self._iot_client.connect()
-        self._iot_client.subscribe(
-            "$aws/things/sesame2/shadow/name/{}/update/accepted".format(
+        subscribe_future, _ = aws_iot.mqtt_connection.subscribe(
+            topic="$aws/things/sesame2/shadow/name/{}/update/accepted".format(
                 self.getDeviceUUID()
             ),
-            1,
-            self._iot_shadow_callback,
+            qos=mqtt.QoS.AT_LEAST_ONCE,
+            callback=self._iot_shadow_callback,
         )
+        return subscribe_future.result()
 
     @property
     def historyEntries(self) -> List["CHSesame2History"]:
@@ -170,7 +137,7 @@ class CHSesame2(SesameLocker):
         Returns:
             list[CHSesame2History]: A list of events.
         """
-        return SesameCloud(self).getHistoryEntries()
+        return self.authenticator.sesame_cloud.getHistoryEntries(self)
 
     def getDeviceShadowStatus(self) -> CHSesame2ShadowStatus:
         """Return a cached shadow status of a device.
@@ -203,7 +170,9 @@ class CHSesame2(SesameLocker):
         Returns:
             bool: `True` if it is successfully locked, `False` if not.
         """
-        result = SesameCloud(self).sendCmd(CHSesame2CMD.LOCK, history_tag)
+        result = self.authenticator.sesame_cloud.sendCmd(
+            self, CHSesame2CMD.LOCK, history_tag
+        )
         if result:
             self.setDeviceShadowStatus(CHSesame2ShadowStatus.LockedWm)
         return result
@@ -217,7 +186,9 @@ class CHSesame2(SesameLocker):
         Returns:
             bool: `True` if it is successfully unlocked, `False` if not.
         """
-        result = SesameCloud(self).sendCmd(CHSesame2CMD.UNLOCK, history_tag)
+        result = self.authenticator.sesame_cloud.sendCmd(
+            self, CHSesame2CMD.UNLOCK, history_tag
+        )
         if result:
             self.setDeviceShadowStatus(CHSesame2ShadowStatus.UnlockedWm)
         return result

--- a/pysesame3/chsesame2.py
+++ b/pysesame3/chsesame2.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 try:
     from awscrt import mqtt
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     pass
 
 from pysesame3.auth import CognitoAuth

--- a/pysesame3/cloud.py
+++ b/pysesame3/cloud.py
@@ -1,6 +1,15 @@
 import base64
 import time
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Union
+
+try:
+    import certifi
+    from awscrt import io, mqtt
+    from awscrt.exceptions import AwsCrtError
+    from awsiot import mqtt_connection_builder
+except ImportError:
+    # Optional deps
+    pass
 
 import requests
 from Crypto.Cipher import AES
@@ -11,17 +20,20 @@ from .helper import CHSesame2MechStatus
 from .history import CHSesame2History
 
 if TYPE_CHECKING:
+    from concurrent.futures import Future
+
+    from .auth import CognitoAuth, WebAPIAuth
     from .chsesame2 import CHSesame2, CHSesame2CMD
 
 
 class SesameCloud:
-    def __init__(self, device: "CHSesame2") -> None:
+    def __init__(self, authenticator: Union["WebAPIAuth", "CognitoAuth"]) -> None:
         """Construct and send a Request to the cloud.
 
         Args:
-            device (CHSesame2): The device for which you want to query.
+            authenticator (Union[WebAPIAuth, CognitoAuth]): The authenticator
         """
-        self._device = device
+        self._authenticator = authenticator
 
     def requestAPI(
         self, method: str, url: str, json: Optional[dict] = None
@@ -44,7 +56,7 @@ class SesameCloud:
                 method,
                 url,
                 json=json,
-                auth=self._device.authenticator,
+                auth=self._authenticator,
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
@@ -52,58 +64,63 @@ class SesameCloud:
 
         return response
 
-    def getSign(self) -> str:
+    def getSign(self, device: "CHSesame2") -> str:
         """Generate a AES-CMAC tag.
 
         Returns:
             str: AES-CMAC tag.
         """
         unixtime = int(time.time())
-        secret = self._device.getSecretKey()
+        secret = device.getSecretKey()
         cobj = CMAC.new(secret, ciphermod=AES)
         cobj.update(unixtime.to_bytes(4, "little")[1:4])
         sign = cobj.hexdigest()
 
         return sign
 
-    def getMechStatus(self) -> CHSesame2MechStatus:
+    def getMechStatus(self, device: "CHSesame2") -> CHSesame2MechStatus:
         """Retrive a mechanical status of a device.
+
+        Args:
+            device (CHSesame2): The device for which you want to query.
 
         Returns:
             CHSesame2MechStatus: Current mechanical status of the device.
         """
-        if self._device.authenticator.login_method == AuthType.WebAPI:
-            url = "{}/{}".format(OFFICIALAPI_URL, self._device.getDeviceUUID())
+        if self._authenticator.login_method == AuthType.WebAPI:
+            url = "{}/{}".format(OFFICIALAPI_URL, device.getDeviceUUID())
             response = self.requestAPI("GET", url)
             r_json = response.json()
             return CHSesame2MechStatus(dictdata=r_json)
         else:
             url = "https://{}/things/sesame2/shadow?name={}".format(
-                IOT_EP, self._device.getDeviceUUID()
+                IOT_EP, device.getDeviceUUID()
             )
-
             response = self.requestAPI("GET", url)
             r_json = response.json()
             return CHSesame2MechStatus(rawdata=r_json["state"]["reported"]["mechst"])
 
-    def sendCmd(self, cmd: "CHSesame2CMD", history_tag: str = "pysesame3") -> bool:
+    def sendCmd(
+        self, device: "CHSesame2", cmd: "CHSesame2CMD", history_tag: str = "pysesame3"
+    ) -> bool:
         """Send a locking/unlocking command.
 
         Args:
+            device (CHSesame2): The device for which you want to query.
             cmd (CHSesame2CMD): Lock, Unlock and Toggle.
             history_tag (CHSesame2CMD): The key tag to sent when locking and unlocking.
 
         Returns:
             bool: `True` if success, `False` if not.
         """
-        if self._device.authenticator.login_method == AuthType.WebAPI:
-            url = "{}/{}/cmd".format(OFFICIALAPI_URL, self._device.getDeviceUUID())
-            sign = self.getSign()
-        elif self._device.authenticator.login_method == AuthType.SDK:
+        if self._authenticator.login_method == AuthType.WebAPI:
+            url = "{}/{}/cmd".format(OFFICIALAPI_URL, device.getDeviceUUID())
+            sign = self.getSign(device)
+        elif self._authenticator.login_method == AuthType.SDK:
             url = "{}/device/v1/iot/sesame2/{}".format(
-                APIGW_URL, self._device.getDeviceUUID()
+                APIGW_URL, device.getDeviceUUID()
             )
-            sign = self.getSign()[0:8]
+            sign = self.getSign(device)[0:8]
 
         payload = {
             "cmd": int(cmd),
@@ -118,19 +135,22 @@ class SesameCloud:
         except RuntimeError:
             return False
 
-    def getHistoryEntries(self) -> List[CHSesame2History]:
+    def getHistoryEntries(self, device: "CHSesame2") -> List[CHSesame2History]:
         """Retrieve the history of all events with a device.
+
+        Args:
+            device (CHSesame2): The device for which you want to query.
 
         Returns:
             list[CHSesame2History]: A list of events.
         """
-        if self._device.authenticator.login_method == AuthType.WebAPI:
+        if self._authenticator.login_method == AuthType.WebAPI:
             url = "{}/{}/history?page=0&lg=10".format(
-                OFFICIALAPI_URL, self._device.getDeviceUUID()
+                OFFICIALAPI_URL, device.getDeviceUUID()
             )
-        elif self._device.authenticator.login_method == AuthType.SDK:
+        elif self._authenticator.login_method == AuthType.SDK:
             url = "{}/device/v1/sesame2/{}/history?page=0&lg=10&a={}".format(
-                APIGW_URL, self._device.getDeviceUUID(), self.getSign()[0:8]
+                APIGW_URL, device.getDeviceUUID(), self.getSign(device)[0:8]
             )
 
         ret = []
@@ -140,3 +160,95 @@ class SesameCloud:
             ret.append(CHSesame2History(**entry))
 
         return ret
+
+
+class AWSIoT:
+    def __init__(self, authenticator: "CognitoAuth") -> None:
+        """Construct and send a request to the AWS IoT.
+
+        Args:
+            authenticator (CognitoAuth): The authenticator
+        """
+        self._authenticator = authenticator
+        self.mqtt_connection: mqtt.Connection
+
+    def _on_connection_interrupted(
+        self, connection: mqtt.Connection, error: AwsCrtError
+    ) -> None:
+        """Callback when connection is accidentally lost.
+
+        Args:
+            connection (mqtt.Connection): Connection this callback is for.
+            error (AwsCrtError): Exception which caused connection loss.
+        """
+        print("Connection interrupted. error: {}".format(error))
+
+    def _on_connection_resumed(
+        self,
+        connection: mqtt.Connection,
+        return_code: mqtt.ConnectReturnCode,
+        session_present: bool,
+    ) -> None:
+        """Callback when an interrupted connection is re-established.
+
+        Args:
+            connection (mqtt.Connection): Connection this callback is for.
+            return_code (mqtt.ConnectReturnCode): Connect return code received from the server.
+            session_present (bool): `True` if resuming existing session. `False` if new session.
+        """
+        print(
+            "Connection resumed. return_code: {} session_present: {}".format(
+                return_code, session_present
+            )
+        )
+
+        if return_code == mqtt.ConnectReturnCode.ACCEPTED and not session_present:
+            print("Session did not persist. Resubscribing to existing topics...")
+            resubscribe_future, _ = connection.resubscribe_existing_topics()
+
+            # Cannot synchronously wait for resubscribe result because we're on the connection's event-loop thread,
+            # evaluate result with a callback instead.
+            resubscribe_future.add_done_callback(self._on_resubscribe_complete)
+
+    def _on_resubscribe_complete(self, resubscribe_future: "Future") -> None:
+        """Callback when resubscribing to existing topics is done.
+
+        Args:
+            resubscribe_future (concurrent.futures.Future): Future which completes when resubscribing succeeds or fails.
+
+        Raises:
+            ConnectionRefusedError: If the server rejected resubscribe to a topic.
+        """
+        resubscribe_results = resubscribe_future.result()
+        print("Resubscribe results: {}".format(resubscribe_results))
+
+        for topic, qos in resubscribe_results["topics"]:
+            if qos is None:
+                raise ConnectionRefusedError(
+                    "Server rejected resubscribe to topic: {}".format(topic)
+                )
+
+    def connect(self) -> None:
+        """Open the actual connection to the server."""
+        if hasattr(self, "mqtt_connection"):
+            connect_future = self.mqtt_connection.connect()
+            return connect_future.result()
+
+        event_loop_group = io.EventLoopGroup(1)
+        host_resolver = io.DefaultHostResolver(event_loop_group)
+        client_bootstrap = io.ClientBootstrap(event_loop_group, host_resolver)
+
+        self.mqtt_connection = mqtt_connection_builder.websockets_with_custom_handshake(
+            endpoint=IOT_EP,
+            client_bootstrap=client_bootstrap,
+            websocket_handshake_transform=self._authenticator.iot_websocket_handshake_transform,
+            ca_filepath=certifi.where(),
+            on_connection_interrupted=self._on_connection_interrupted,
+            on_connection_resumed=self._on_connection_resumed,
+            client_id=self._authenticator.client_id,
+            clean_session=False,
+            keep_alive_secs=6,
+        )
+
+        connect_future = self.mqtt_connection.connect()
+        connect_future.result()

--- a/pysesame3/cloud.py
+++ b/pysesame3/cloud.py
@@ -8,7 +8,7 @@ try:
     from awscrt import io, mqtt
     from awscrt.exceptions import AwsCrtError
     from awsiot import mqtt_connection_builder
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     pass
 
 import requests
@@ -169,7 +169,9 @@ class AWSIoT:
         Args:
             authenticator (CognitoAuth): The authenticator
         """
-        if "awsiot" not in sys.modules or "certifi" not in sys.modules: # pragma: no cover
+        if (
+            "awsiot" not in sys.modules or "certifi" not in sys.modules
+        ):  # pragma: no cover
             raise RuntimeError(
                 "Failed to load awsiotsdk or certifi. Did you run `pip install pysesame3[cognito]`?"
             )

--- a/pysesame3/cloud.py
+++ b/pysesame3/cloud.py
@@ -1,4 +1,5 @@
 import base64
+import sys
 import time
 from typing import TYPE_CHECKING, List, Optional, Union
 
@@ -7,8 +8,7 @@ try:
     from awscrt import io, mqtt
     from awscrt.exceptions import AwsCrtError
     from awsiot import mqtt_connection_builder
-except ImportError:
-    # Optional deps
+except ImportError: # pragma: no cover
     pass
 
 import requests
@@ -169,6 +169,11 @@ class AWSIoT:
         Args:
             authenticator (CognitoAuth): The authenticator
         """
+        if "awsiot" not in sys.modules or "certifi" not in sys.modules: # pragma: no cover
+            raise RuntimeError(
+                "Failed to load awsiotsdk or certifi. Did you run `pip install pysesame3[cognito]`?"
+            )
+
         self._authenticator = authenticator
         self.mqtt_connection: mqtt.Connection
 

--- a/pysesame3/helper.py
+++ b/pysesame3/helper.py
@@ -1,4 +1,5 @@
 import importlib
+import re
 import sys
 from enum import Enum
 from typing import Optional, Union
@@ -191,3 +192,15 @@ class CHSesame2MechStatus:
             bool: `True` if it is unlocked, `False` if not.
         """
         return self._isInUnlockRange
+
+
+class RegexHelper:
+    @staticmethod
+    def get_aws_region(text: str) -> str:
+        result = re.search(
+            r"(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d", text
+        )
+        if result:
+            return result.group(0)
+        else:
+            raise ValueError("Failed to extract a region name.")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,8 @@
 """Tests for `pysesame3` package."""
 
 import pytest
+import requests
+from moto import mock_cognitoidentity
 
 from pysesame3.auth import CognitoAuth, WebAPIAuth
 
@@ -38,3 +40,28 @@ def test_CognitoAuth_raises_exception_on_invalid_apikey():
             apikey="fake", client_id="us-east-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         )
     assert "length should be 40" in str(excinfo.value)
+
+
+def test_CognitoAuth_call_raises_exception_on_broken_PreparedRequest():
+    c = CognitoAuth(
+        apikey="FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE",
+        client_id="us-east-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+    req = requests.PreparedRequest()
+
+    with pytest.raises(TypeError):
+        c(req)
+
+
+@mock_cognitoidentity
+def test_CognitoAuth_authenticate():
+    c = CognitoAuth(
+        apikey="FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE",
+        client_id="us-east-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+
+    (access_key_id, secret_key, session_token) = c.authenticate()
+
+    assert access_key_id == "TESTACCESSKEY12345"
+    assert secret_key == "ABCSECRETKEY"
+    assert session_token == "ABC12345"

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -2,11 +2,20 @@
 
 """Tests for `pysesame3` package."""
 
+import asyncio
+import sys
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest import patch
+else:
+    from unittest.mock import patch
+
 import pytest
 import requests_mock
 from moto import mock_cognitoidentity
 
-from pysesame3.cloud import SesameCloud
+from pysesame3.auth import CognitoAuth
+from pysesame3.cloud import AWSIoT, SesameCloud
 
 from .utils import load_fixture
 
@@ -31,3 +40,36 @@ class TestSesameCloudBroken:
         with pytest.raises(TypeError) as excinfo:
             SesameCloud()
         assert "missing 1 required positional argument" in str(excinfo.value)
+
+
+class TestAWSIoTBroken:
+    def test_AWSIoT_raises_exception_on_authenticator_missing(self):
+        with pytest.raises(TypeError) as excinfo:
+            AWSIoT()
+        assert "missing 1 required positional argument" in str(excinfo.value)
+
+
+class TestAWSIoT:
+    @pytest.fixture(autouse=True)
+    def aws_iot(self):
+        with mock_cognitoidentity():
+            cl = CognitoAuth(
+                apikey="FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE",
+                client_id="ap-northeast-1:fakefakefake",
+            )
+            yield AWSIoT(cl)
+
+    def test_AWSIoT_connect(self, aws_iot):
+        with patch("pysesame3.cloud.mqtt.Connection.connect") as connect:
+
+            def _connect(*args, **kwargs):
+                f = asyncio.Future()
+                f.set_result(True)
+                return f
+
+            connect.side_effect = _connect
+            aws_iot.connect()
+            connect.assert_called_once()
+
+            aws_iot.connect()
+            assert connect.call_count == 2

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from pysesame3.helper import CHProductModel, CHSesame2MechStatus
+from pysesame3.helper import CHProductModel, CHSesame2MechStatus, RegexHelper
 
 
 class TestCHProductModel:
@@ -155,4 +155,28 @@ class TestCHSesame2MechStatus:
         assert (
             str(status)
             == "CHSesame2MechStatus(Battery=100% (6.05V), isInLockRange=False, isInUnlockRange=True, Position=739)"
+        )
+
+
+class TestRegexHelper:
+    def test_get_aws_region_raises_exception_with_unknown_str(self):
+        with pytest.raises(ValueError):
+            RegexHelper.get_aws_region("INVALID")
+
+    def test_get_aws_region(self):
+        assert (
+            RegexHelper.get_aws_region(
+                "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod"
+            )
+            == "ap-northeast-1"
+        )
+        assert (
+            RegexHelper.get_aws_region(
+                "a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com"
+            )
+            == "ap-northeast-1"
+        )
+        assert (
+            RegexHelper.get_aws_region("us-west-1:126D3D66-9222-4E5A-BCDE-0C6629D48D43")
+            == "us-west-1"
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,3 +9,11 @@ def load_fixture(filename):
     ) as fp:
         data = json.load(fp)
     return data
+
+
+class TypeMatcher:
+    def __init__(self, expected_type):
+        self.expected_type = expected_type
+
+    def __eq__(self, other):
+        return isinstance(other, self.expected_type)

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
 basepython = python3
 deps = poetry
 commands =
-   poetry install --no-root -v -E doc
+   poetry install --no-root -v -E doc -E cognito
    poetry run mkdocs build
 
 [testenv:packaging]


### PR DESCRIPTION
As pointed out in #37 and https://github.com/mochipon/pysesame3/pull/33?w=1#issuecomment-873359096, the AWS IoT Device SDK v1 has several issues and is not really maintained by the developers. With this PR, we migrate a project from v1 to v2 in order to fix #37. The sample script has been running stable for over a week with this code base.

Not only that, but we decoupled the AWS IoT connection object from a device object (`CHSesame2`) and fixes #40.