### PR TITLE
Support SESAME bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ If you want to control them directly via **Bluetooth connection**, please check 
 * Free software: MIT license
 * Documentation: [https://pysesame3.readthedocs.io](https://pysesame3.readthedocs.io)
 
+## Supported devices
+
+- [SESAME 3](https://jp.candyhouse.co/products/sesame3)
+- [SESAME bot](https://jp.candyhouse.co/products/sesame3-bot)
+
 ## Features
 
-Please note that `pysesame3` can only control [SESAME 3 Smart Lock](https://jp.candyhouse.co/products/sesame3) at this moment. It could technically support [SESAME Bot](https://jp.candyhouse.co/collections/frontpage/products/sesame3-bot) as well, but I don't have that device. PRs are always welcome!
-
-* Retrieve status of a SESAME lock (locked, handle position, etc.).
+* Retrieve the device status (battery level, locked, handle position, etc.).
 * Retrieve recent events (locked, unlocked, etc.) associated with a lock.
-* Needless to say, locking and unlocking!
+* Needless to say, locking, unlocking and clicking (for the bot)!
 
 ## Usage
 
@@ -30,4 +33,5 @@ Please take a look at [the documentation](https://pysesame3.readthedocs.io/en/la
 ## Credits & Thanks
 
 * A huge thank you to all at [CANDY HOUSE](https://jp.candyhouse.co/) and their crowdfunding contributors!
+* Thanks to [@Chabiichi](https://github.com/Chabiichi)-san for [the offer](https://github.com/mochipon/pysesame3/issues/25) to get my SESAME bot!
 * This project was inspired and based on [tchellomello/python-ring-doorbell](https://github.com/tchellomello/python-ring-doorbell) and [snjoetw/py-august](https://github.com/snjoetw/py-august).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,12 +5,13 @@ import time
 from pprint import pprint
 
 from pysesame3.auth import CognitoAuth, WebAPIAuth
-from pysesame3.cloud import SesameCloud
-from pysesame3.helper import CHSesame2MechStatus
-from pysesame3.chsesame2 import CHSesame2
+from pysesame3.chsesame2 import CHSesame2  # For SESAME 3
+from pysesame3.chsesamebot import CHSesameBot  # For SESAME bot
+from pysesame3.device import SesameLocker  # Just for type hinting
+from pysesame3.helper import CHSesame2MechStatus  # Just for type hinting
 
 
-def callback(device: CHSesame2, status: CHSesame2MechStatus):
+def callback(device: SesameLocker, status: CHSesame2MechStatus):
     print("=" * 10)
     print("mechStatus is updated!")
     print("UUID: {}".format(device.getDeviceUUID()))
@@ -45,6 +46,12 @@ def main():
     your_key_uuid = "UUID"
     your_key_secret = "SECRET_KEY"
 
+    """
+    This library supports SESAME3 and SESAME bot.
+
+    `CHSesame2`: SESAME3
+    `CHSesameBot`: SESAME bot
+    """
     device = CHSesame2(
         authenticator=auth, device_uuid=your_key_uuid, secret_key=your_key_secret
     )
@@ -77,6 +84,20 @@ def main():
     In the same way, you can **subscribe** to `mechStatus`.
     """
     device.subscribeMechStatus(callback)
+
+    """
+    It also supports environments where multiple locks are being installed.
+
+    your_2nd_key_uuid = "UUID"
+    your_2nd_key_secret = "SECRET_KEY"
+
+    device2 = CHSesame2(
+        authenticator=auth,
+        device_uuid=your_2nd_key_uuid,
+        secret_key=your_2nd_key_secret,
+    )
+    device2.subscribeMechStatus(callback)
+    """
 
     print("=" * 10)
     print("[History]")

--- a/pysesame3/chsesamebot.py
+++ b/pysesame3/chsesamebot.py
@@ -19,14 +19,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class CHSesame2(SesameLocker):
+class CHSesameBot(SesameLocker):
     def __init__(
         self,
         authenticator: Union["WebAPIAuth", "CognitoAuth"],
         device_uuid: str,
         secret_key: str,
     ) -> None:
-        """SESAME3 Device Specific Implementation.
+        """SESAME bot Device Specific Implementation.
 
         Args:
             authenticator (Union[WebAPIAuth, CognitoAuth]):
@@ -38,7 +38,7 @@ class CHSesame2(SesameLocker):
         self.setDeviceUUID(device_uuid)
         self.setSecretKey(secret_key)
         self._callback: Optional[
-            Callable[[CHSesame2, CHSesame2MechStatus], None]
+            Callable[[CHSesameBot, CHSesame2MechStatus], None]
         ] = None
 
         # Initial sync of `self._deviceShadowStatus`
@@ -101,12 +101,12 @@ class CHSesame2(SesameLocker):
 
     def subscribeMechStatus(
         self,
-        callback: Optional[Callable[["CHSesame2", CHSesame2MechStatus], None]] = None,
+        callback: Optional[Callable[["CHSesameBot", CHSesame2MechStatus], None]] = None,
     ) -> None:
         """Subscribe to a topic at AWS IoT
 
         Args:
-            callback (Callable[[CHSesame2, CHSesame2MechStatus], None], optional): The registered callback will be executed once an update is delivered. Defaults to `None`.
+            callback (Callable[[CHSesameBot, CHSesame2MechStatus], None], optional): The registered callback will be executed once an update is delivered. Defaults to `None`.
 
         Raises:
             NotImplementedError: If the authenticator is not `AuthType.SDK`.
@@ -172,7 +172,7 @@ class CHSesame2(SesameLocker):
         logger.debug("UUID={}, set={}".format(self.getDeviceUUID(), status))
         self._deviceShadowStatus = status
 
-    def lock(self, history_tag: str = "pysesame3") -> bool:
+    def click(self, history_tag: str = "pysesame3") -> bool:
         """Locking.
 
         Args:
@@ -181,44 +181,13 @@ class CHSesame2(SesameLocker):
         Returns:
             bool: `True` if it is successfully locked, `False` if not.
         """
-        logger.info("UUID={}, Locking...".format(self.getDeviceUUID()))
+        logger.info("UUID={}, Clicking...".format(self.getDeviceUUID()))
         result = self.authenticator.sesame_cloud.sendCmd(
-            self, CHSesame2CMD.LOCK, history_tag
+            self, CHSesame2CMD.CLICK, history_tag
         )
         if result:
             self.setDeviceShadowStatus(CHSesame2ShadowStatus.LockedWm)
         return result
-
-    def unlock(self, history_tag: str = "pysesame3") -> bool:
-        """Unlocking.
-
-        Args:
-            history_tag (str): The key tag to sent when locking and unlocking. Defaults to `pysesame3`.
-
-        Returns:
-            bool: `True` if it is successfully unlocked, `False` if not.
-        """
-        logger.info("UUID={}, Unlocking...".format(self.getDeviceUUID()))
-        result = self.authenticator.sesame_cloud.sendCmd(
-            self, CHSesame2CMD.UNLOCK, history_tag
-        )
-        if result:
-            self.setDeviceShadowStatus(CHSesame2ShadowStatus.UnlockedWm)
-        return result
-
-    def toggle(self, history_tag: str = "pysesame3") -> bool:
-        """Toggle.
-
-        Args:
-            history_tag (str): The key tag to sent when locking and unlocking. Defaults to `pysesame3`.
-
-        Returns:
-            bool: `True` if it is successfully toggled, `False` if not.
-        """
-        if self.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm:
-            return self.unlock(history_tag)
-        else:
-            return self.lock(history_tag)
 
     def __str__(self) -> str:
         """Return a string representation of an object.
@@ -226,4 +195,4 @@ class CHSesame2(SesameLocker):
         Returns:
             str: The string representation of the object.
         """
-        return f"CHSesame2(deviceUUID={self.getDeviceUUID()}, deviceModel={self.productModel}, mechStatus={self.mechStatus})"
+        return f"CHSesameBot(deviceUUID={self.getDeviceUUID()}, deviceModel={self.productModel}, mechStatus={self.mechStatus})"

--- a/pysesame3/cloud.py
+++ b/pysesame3/cloud.py
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
     from concurrent.futures import Future
 
     from .auth import CognitoAuth, WebAPIAuth
-    from .chsesame2 import CHSesame2, CHSesame2CMD
+    from .const import CHSesame2CMD
+    from .device import SesameLocker
+
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +71,7 @@ class SesameCloud:
 
         return response
 
-    def getSign(self, device: "CHSesame2") -> str:
+    def getSign(self, device: "SesameLocker") -> str:
         """Generate a AES-CMAC tag.
 
         Returns:
@@ -84,11 +86,11 @@ class SesameCloud:
 
         return sign
 
-    def getMechStatus(self, device: "CHSesame2") -> CHSesame2MechStatus:
+    def getMechStatus(self, device: "SesameLocker") -> CHSesame2MechStatus:
         """Retrive a mechanical status of a device.
 
         Args:
-            device (CHSesame2): The device for which you want to query.
+            device (SesameLocker): The device for which you want to query.
 
         Returns:
             CHSesame2MechStatus: Current mechanical status of the device.
@@ -107,12 +109,15 @@ class SesameCloud:
             return CHSesame2MechStatus(rawdata=r_json["state"]["reported"]["mechst"])
 
     def sendCmd(
-        self, device: "CHSesame2", cmd: "CHSesame2CMD", history_tag: str = "pysesame3"
+        self,
+        device: "SesameLocker",
+        cmd: "CHSesame2CMD",
+        history_tag: str = "pysesame3",
     ) -> bool:
         """Send a locking/unlocking command.
 
         Args:
-            device (CHSesame2): The device for which you want to query.
+            device (SesameLocker): The device for which you want to query.
             cmd (CHSesame2CMD): Lock, Unlock and Toggle.
             history_tag (CHSesame2CMD): The key tag to sent when locking and unlocking.
 
@@ -148,11 +153,11 @@ class SesameCloud:
             logger.debug("sendCmd result=exception raised")
             return False
 
-    def getHistoryEntries(self, device: "CHSesame2") -> List[CHSesame2History]:
+    def getHistoryEntries(self, device: "SesameLocker") -> List[CHSesame2History]:
         """Retrieve the history of all events with a device.
 
         Args:
-            device (CHSesame2): The device for which you want to query.
+            device (SesameLocker): The device for which you want to query.
 
         Returns:
             list[CHSesame2History]: A list of events.

--- a/pysesame3/const.py
+++ b/pysesame3/const.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum, IntEnum, auto
 
 OFFICIALAPI_URL = "https://app.candyhouse.co/api/sesame2"
 APIGW_URL = "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod"
@@ -8,3 +8,16 @@ IOT_EP = "a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com"
 class AuthType(Enum):
     WebAPI = auto()
     SDK = auto()
+
+
+class CHSesame2CMD(IntEnum):
+    LOCK = 82
+    UNLOCK = 83
+    TOGGLE = 88
+    CLICK = 89
+
+
+class CHSesame2ShadowStatus(Enum):
+    LockedWm = auto()
+    UnlockedWm = auto()
+    MovedWm = auto()

--- a/pysesame3/helper.py
+++ b/pysesame3/helper.py
@@ -30,6 +30,12 @@ class CHProductModel(Enum):
         "productType": 0,
         "deviceFactory": "CHSesame2",
     }
+    SesameBot1: ProductData = {
+        "deviceModel": "ssmbot_1",
+        "isLocker": True,
+        "productType": 2,
+        "deviceFactory": "CHSesameBot",
+    }
 
     @staticmethod
     def getByModel(model: str) -> "CHProductModel":

--- a/pysesame3/history.py
+++ b/pysesame3/history.py
@@ -15,6 +15,7 @@ class CHSesame2History:
     """
 
     class EventType(IntEnum):
+        unknown = -1
         none = 0
         bleLock = 1
         bleUnLock = 2
@@ -33,6 +34,10 @@ class CHSesame2History:
         wm2UnLock = 15
         webLock = 16
         webUnLock = 17
+        # 18 will be wm2Click or webClick
+        EVENT_18 = 18
+        driveClick = 21
+        manualClick = 22
 
     def __init__(
         self,
@@ -43,7 +48,10 @@ class CHSesame2History:
         devicePk: Optional[str] = None,
         parameter=None,
     ) -> None:
-        self.event_type = CHSesame2History.EventType(type)
+        try:
+            self.event_type = CHSesame2History.EventType(type)
+        except ValueError:
+            self.event_type = CHSesame2History.EventType.unknown
         self.timestamp = datetime.fromtimestamp(timeStamp / 1000)
         self.record_id = recordID
         self.historytag = historyTag

--- a/tests/test_chsesamebot.py
+++ b/tests/test_chsesamebot.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python
+
+"""Tests for `pysesame3` package."""
+
+import json
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+import requests_mock
+from moto import mock_cognitoidentity
+
+from pysesame3.auth import CognitoAuth, WebAPIAuth
+from pysesame3.chsesamebot import CHSesameBot
+from pysesame3.const import CHSesame2ShadowStatus
+from pysesame3.history import CHSesame2History
+
+from .utils import load_fixture
+
+
+@pytest.fixture(autouse=True)
+def mock_requests():
+    with requests_mock.Mocker() as mock:
+        mock.get(
+            "https://app.candyhouse.co/api/sesame2/126d3d66-9222-4e5a-bcde-0c6629d48d43",
+            json=load_fixture("lock_get_locked.json"),
+        )
+
+        mock.get(
+            "https://app.candyhouse.co/api/sesame2/e0e56521-63d8-4da5-ba4b-c4a6a5e353f1",
+            json=load_fixture("lock_get_unlocked.json"),
+        )
+
+        mock.post(
+            "https://app.candyhouse.co/api/sesame2/126d3d66-9222-4e5a-bcde-0c6629d48d43/cmd"
+        )
+
+        mock.post(
+            "https://app.candyhouse.co/api/sesame2/e0e56521-63d8-4da5-ba4b-c4a6a5e353f1/cmd"
+        )
+
+        mock.get(
+            "https://a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com/things/sesame2/shadow?name=126D3D66-9222-4E5A-BCDE-0C6629D48D43",
+            json=load_fixture("lock_shadow_locked.json"),
+        )
+
+        mock.get(
+            "https://a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com/things/sesame2/shadow?name=E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1",
+            json=load_fixture("lock_shadow_unlocked.json"),
+        )
+
+        mock.post(
+            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/iot/sesame2/126D3D66-9222-4E5A-BCDE-0C6629D48D43"
+        )
+
+        mock.post(
+            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/iot/sesame2/E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1"
+        )
+
+        mock.get(
+            "https://app.candyhouse.co/api/sesame2/126d3d66-9222-4e5a-bcde-0c6629d48d43/history?page=0&lg=10",
+            json=load_fixture("history.json"),
+        )
+
+        mock.get(
+            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/sesame2/126D3D66-9222-4E5A-BCDE-0C6629D48D43/history",
+            json=load_fixture("history.json"),
+        )
+        yield mock
+
+
+@pytest.fixture()
+def mock_cloud():
+    cl = WebAPIAuth(apikey="FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE")
+    yield cl
+
+
+@pytest.fixture()
+def mock_cloud_cognito():
+    with mock_cognitoidentity():
+        cl = CognitoAuth(
+            apikey="FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE",
+            client_id="ap-northeast-1:fakefakefake",
+        )
+        yield cl
+
+
+class TestCHSesameBotBroken:
+    def test_CHSesameBot_raises_exception_on_missing_arguments(self):
+        with pytest.raises(TypeError):
+            CHSesameBot()
+
+        with pytest.raises(TypeError):
+            CHSesameBot(mock_cloud)
+
+    def test_CHSesameBot_raises_exception_on_invalid_arguments(self):
+        with pytest.raises(ValueError):
+            key = {
+                "device_uuid": "FAKEUUID",
+                "secret_key": "0b3e5f1665e143b59180c915fa4b06d9",
+            }
+            CHSesameBot(mock_cloud, **key)
+
+        with pytest.raises(ValueError):
+            key = {
+                "device_uuid": "126D3D66-9222-4E5A-BCDE-0C6629D48D43",
+                "secret_key": "FAKE_SECRET_KEY",
+            }
+            CHSesameBot(mock_cloud, **key)
+
+
+class TestCHSesameBot:
+    @pytest.fixture(autouse=True)
+    def _initialize_key(self, mock_cloud):
+        key = {
+            "device_uuid": "126D3D66-9222-4E5A-BCDE-0C6629D48D43",
+            "secret_key": "0b3e5f1665e143b59180c915fa4b06d9",
+        }
+        self.key_locked = CHSesameBot(mock_cloud, **key)
+
+    def test_CHSesameBot(self):
+        assert (
+            str(self.key_locked)
+            == "CHSesameBot(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=None, mechStatus=CHSesame2MechStatus(Battery=67% (5.87V), isInLockRange=True, isInUnlockRange=False, Position=11))"
+        )
+
+    def test_CHSesameBot_subscribeMechStatus_raises_exception_with_WebAPI(self):
+        def _callback(*_):
+            return True
+
+        with pytest.raises(NotImplementedError):
+            self.key_locked.subscribeMechStatus(_callback)
+
+    def test_CHSesameBot_getDeviceShadowStatus(self):
+        assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
+
+    def test_SesameCloud_getHistoryEntries(self):
+        entries = self.key_locked.historyEntries
+
+        assert isinstance(entries, list)
+        assert len(entries) == 2
+        assert isinstance(entries[0], CHSesame2History)
+        assert isinstance(entries[1], CHSesame2History)
+
+    def test_CHSesameBot_setDeviceShadowStatus_toggle(self):
+        assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
+        self.key_locked.setDeviceShadowStatus(CHSesame2ShadowStatus.UnlockedWm)
+        assert (
+            self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.UnlockedWm
+        )
+
+    def test_CHSesameBot_setDeviceShadowStatus_raises_exception_on_invalid_status(self):
+        with pytest.raises(ValueError):
+            self.key_locked.setDeviceShadowStatus("INVALID")
+
+    def test_CHSesameBot_click_fails_HTTP_requests(self):
+        with requests_mock.Mocker() as mock:
+            mock.post(
+                "https://app.candyhouse.co/api/sesame2/126d3d66-9222-4e5a-bcde-0c6629d48d43/cmd",
+                status_code=500,
+            )
+            assert not self.key_locked.click()
+            assert (
+                self.key_locked.getDeviceShadowStatus()
+                == CHSesame2ShadowStatus.LockedWm
+            )
+
+    def test_CHSesameBot_click(self):
+        assert self.key_locked.click()
+        assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
+
+
+class TestCHSesameBotCognito:
+    @pytest.fixture(autouse=True)
+    def _initialize_key(self, mock_cloud_cognito):
+        key = {
+            "device_uuid": "126D3D66-9222-4E5A-BCDE-0C6629D48D43",
+            "secret_key": "0b3e5f1665e143b59180c915fa4b06d9",
+        }
+        self.key_locked = CHSesameBot(mock_cloud_cognito, **key)
+
+        key = {
+            "device_uuid": "E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1",
+            "secret_key": "0b3e5f1665e143b59180c915fa4b06d9",
+        }
+        self.key_unlocked = CHSesameBot(mock_cloud_cognito, **key)
+
+    def test_CHSesameBot(self):
+        assert (
+            str(self.key_locked)
+            == "CHSesameBot(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=None, mechStatus=CHSesame2MechStatus(Battery=100% (6.11V), isInLockRange=True, isInUnlockRange=False, Position=29))"
+        )
+
+    def test_CHSesameBot_iot_shadow_callback_with_missing_mechst(self):
+        assert (
+            self.key_locked._iot_shadow_callback(
+                "$aws/things/sesame2/shadow/name/126D3D66-9222-4E5A-BCDE-0C6629D48D43/update/accepted",
+                json.dumps(load_fixture("lock_shadow_missing_mechst.json")).encode(),
+            )
+            is None
+        )
+        assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
+
+    def test_CHSesameBot_iot_shadow_callback_state_changes_to_unlocked(self):
+        assert (
+            self.key_locked._iot_shadow_callback(
+                "$aws/things/sesame2/shadow/name/126D3D66-9222-4E5A-BCDE-0C6629D48D43/update/accepted",
+                json.dumps(load_fixture("lock_shadow_unlocked.json")).encode(),
+            )
+            is None
+        )
+        assert (
+            self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.UnlockedWm
+        )
+
+    def test_CHSesameBot_iot_shadow_callback_state_changes_to_locked(self):
+        assert (
+            self.key_unlocked._iot_shadow_callback(
+                "$aws/things/sesame2/shadow/name/E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1/update/accepted",
+                json.dumps(load_fixture("lock_shadow_locked.json")).encode(),
+            )
+            is None
+        )
+        assert (
+            self.key_unlocked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
+        )
+
+    def test_CHSesameBot_subscribeMechStatus_raises_exception_on_invalid_arguments(
+        self,
+    ):
+        with pytest.raises(TypeError):
+            self.key_locked.subscribeMechStatus("NOT-CALLABLE")
+
+    def test_CHSesameBot_subscribeMechStatus(self):
+        # TODO: Make tests using moto
+        pass
+
+    def test_CHSesameBot_getDeviceShadowStatus(self):
+        assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
+        assert (
+            self.key_unlocked.getDeviceShadowStatus()
+            == CHSesame2ShadowStatus.UnlockedWm
+        )
+
+    def test_SesameCloud_getHistoryEntries(self):
+        entries = self.key_locked.historyEntries
+
+        assert isinstance(entries, list)
+        assert len(entries) == 2
+        assert isinstance(entries[0], CHSesame2History)
+        assert isinstance(entries[1], CHSesame2History)
+
+    def test_CHSesameBot_setDeviceShadowStatus_toggle(self):
+        assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
+        self.key_locked.setDeviceShadowStatus(CHSesame2ShadowStatus.UnlockedWm)
+        assert (
+            self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.UnlockedWm
+        )
+
+    def test_CHSesameBot_setDeviceShadowStatus_raises_exception_on_invalid_status(self):
+        with pytest.raises(ValueError):
+            self.key_locked.setDeviceShadowStatus("INVALID")
+
+    def test_CHSesameBot_click_fails_HTTP_requests(self):
+        with requests_mock.Mocker() as mock:
+            mock.post(
+                "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/iot/sesame2/E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1",
+                status_code=500,
+            )
+            assert not self.key_unlocked.click()
+            assert (
+                self.key_unlocked.getDeviceShadowStatus()
+                == CHSesame2ShadowStatus.UnlockedWm
+            )
+
+    def test_CHSesameBot_click(self):
+        assert self.key_locked.click()
+        assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -29,9 +29,9 @@ class TestCHSesame2History:
             CHSesame2History.EventType(12345)
         assert "12345 is not a valid" in str(excinfo.value)
 
-        with pytest.raises(ValueError) as excinfo:
-            CHSesame2History(type=12345, timeStamp=1597492862, recordID=1)
-        assert "12345 is not a valid" in str(excinfo.value)
+    def test_CHSesame2History_passes_on_unknown_event_type(self):
+        his = CHSesame2History(type=12345, timeStamp=1597492862, recordID=1)
+        assert his.event_type == CHSesame2History.EventType.unknown
 
     def test_CHSesame2History(self):
         h = CHSesame2History(**(self._json_entries[0]))


### PR DESCRIPTION
Thanks to [@Chabiichi](https://github.com/Chabiichi)-san, I was able to get one SESAME bot. His offer is very much appreciated.

This PR is the initial try to support SESAME bot. I have three concerns at this point.

1. SESAME bot can only be used to **click** at the official app. However, as strange as it may sound, the API allows you to lock and unlock. That is, instead of a series of press and release, you can instruct it to just press or release. For now, the implementation will be the same as the official app, where **only clicks are possible**. 
2. In fact, the two implementations of `CHSesame2` and `CHSesameBot` were exactly the same. It would be better to move their common parts to `SesameLocker`.  The reason I hesitate to do so at this point is that I cannot imagine how the upcoming release of _SesameOS2 updated_ Sesame1 will be implemented.
3. I don't know what [history event type `18`](https://github.com/mochipon/pysesame3/blob/ab8162d03221111889f8dd60c6945effc7c40eee/pysesame3/history.py#L38) is supposed to mean. This will be recorded when the CLICK command is delivered. However, the same number is returned whether the event is triggered via Bluetooth (`bleClick`) or via WiFi module (`wm2Click`). The history handling related to SESAME bot is [implemented in the SDK for iOS but not for Android](https://doc.candyhouse.co/ja/reference#chsesame2history) and unfortunately I am implementing `pysesame3` based on the SDK for Android.