### PR TITLE
SESAME4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pysesame3
 
-_Unofficial Python Library to communicate with SESAME 3 series products from CANDY HOUSE, Inc._
+_Unofficial Python Library for SESAME products from CANDY HOUSE, Inc._
 
 [![PyPI](https://img.shields.io/pypi/v/pysesame3)](https://pypi.python.org/pypi/pysesame3)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pysesame3)
@@ -9,8 +9,7 @@ _Unofficial Python Library to communicate with SESAME 3 series products from CAN
 [![codecov](https://codecov.io/gh/mochipon/pysesame3/branch/main/graph/badge.svg?token=2Y7OPZTILT)](https://codecov.io/gh/mochipon/pysesame3)
 ![PyPI - License](https://img.shields.io/pypi/l/pysesame3)
 
-This project aims to control SESAME 3 series devices by using **[the cloud service](https://doc.candyhouse.co/ja/flow_charts#candy-house-cloud-%E3%81%A8-wifi-module-%E7%B5%8C%E7%94%B1%E3%81%A7-sesame-%E3%82%92%E9%81%A0%E9%9A%94%E6%93%8D%E4%BD%9C)**.
-If you want to control them directly via **Bluetooth connection**, please check [pysesameos2](https://github.com/mochipon/pysesameos2).
+This project aims to control SESAME devices by using **[the cloud service](https://doc.candyhouse.co/ja/flow_charts#candy-house-cloud-%E3%81%A8-wifi-module-%E7%B5%8C%E7%94%B1%E3%81%A7-sesame-%E3%82%92%E9%81%A0%E9%9A%94%E6%93%8D%E4%BD%9C)**.
 
 * Free software: MIT license
 * Documentation: [https://pysesame3.readthedocs.io](https://pysesame3.readthedocs.io)
@@ -18,6 +17,7 @@ If you want to control them directly via **Bluetooth connection**, please check 
 ## Supported devices
 
 - [SESAME 3](https://jp.candyhouse.co/products/sesame3)
+- [SESAME 4](https://jp.candyhouse.co/products/sesame4)
 - [SESAME bot](https://jp.candyhouse.co/products/sesame3-bot)
 
 ## Features
@@ -29,6 +29,26 @@ If you want to control them directly via **Bluetooth connection**, please check 
 ## Usage
 
 Please take a look at [the documentation](https://pysesame3.readthedocs.io/en/latest/usage/).
+
+## Related Projects
+
+### Libraries
+| Name | Lang | Communication Method |
+----|----|----
+| [pysesame](https://github.com/trisk/pysesame) | Python | [Sesame API v1/v2](https://docs.candyhouse.co/v1.html)
+| [pysesame2](https://github.com/yagami-cerberus/pysesame2) | Python | [Sesame API v3](https://docs.candyhouse.co/)
+| [pysesame3](https://github.com/mochipon/pysesame3) | Python | [Web API](https://doc.candyhouse.co/ja/SesameAPI), [CognitoAuth (The official android SDK reverse-engineered)](https://doc.candyhouse.co/ja/android)
+| [pysesameos2](https://github.com/mochipon/pysesameos2) | Python | [Bluetooth](https://doc.candyhouse.co/ja/android)
+
+### Integrations
+| Name | Description | Communication Method |
+----|----|----
+| [doorman](https://github.com/jp7eph/doorman) | Control SESAME3 from Homebridge by MQTT | [Web API](https://doc.candyhouse.co/ja/SesameAPI)
+| [Doorlock](https://github.com/kishikawakatsumi/Doorlock) | iOS widget for Sesame 3 smart lock | [Web API](https://doc.candyhouse.co/ja/SesameAPI)
+| [gopy-sesame3](https://github.com/orangekame3/gopy-sesame3) | NFC (Felica) integration | [Web API](https://doc.candyhouse.co/ja/SesameAPI)
+| [homebridge-open-sesame](https://github.com/yasuoza/homebridge-open-sesame) | Homebridge plugin for SESAME3 | Cognito integration
+| [homebridge-sesame-os2](https://github.com/nzws/homebridge-sesame-os2) | Homebridge Plugin for SESAME OS2 (SESAME3) | [Web API](https://doc.candyhouse.co/ja/SesameAPI)
+| [sesame3-webhook](https://github.com/kunikada/sesame3-webhook) | Send SESAME3 status to specified url. (HTTP Post) | CognitoAuth (based on `pysesame3`)
 
 ## Credits & Thanks
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,7 +5,7 @@ from pprint import pprint
 from typing import TYPE_CHECKING, Union
 
 from pysesame3.auth import CognitoAuth, WebAPIAuth
-from pysesame3.chsesame2 import CHSesame2  # For SESAME 3
+from pysesame3.chsesame2 import CHSesame2  # For SESAME 3, 4
 from pysesame3.chsesamebot import CHSesameBot  # For SESAME bot
 from pysesame3.helper import CHProductModel
 
@@ -56,9 +56,9 @@ def main():
     your_key_secret = "SECRET_KEY"
 
     """
-    This library supports SESAME3 and SESAME bot.
+    This library supports SESAME 3, SESAME 4, and SESAME bot.
 
-    `CHSesame2`: SESAME3
+    `CHSesame2`: SESAME 3, 4
     `CHSesameBot`: SESAME bot
     """
     device = CHSesame2(
@@ -118,7 +118,7 @@ def main():
     while True:
         val = input("Action [lock/unlock/toggle/click]: ")
 
-        if device.productModel == CHProductModel.SS2:
+        if device.productModel in [CHProductModel.SS2, CHProductModel.SS4]:
             if val == "lock":
                 device.lock(history_tag="My Script")
             elif val == "unlock":

--- a/pysesame3/helper.py
+++ b/pysesame3/helper.py
@@ -30,6 +30,12 @@ class CHProductModel(Enum):
         "productType": 0,
         "deviceFactory": "CHSesame2",
     }
+    SS4: ProductData = {
+        "deviceModel": "sesame_4",
+        "isLocker": True,
+        "productType": 4,
+        "deviceFactory": "CHSesame2",
+    }
     SesameBot1: ProductData = {
         "deviceModel": "ssmbot_1",
         "isLocker": True,

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -25,6 +25,13 @@ class TestCHProductModel:
         assert ss2.productType() == 0
         assert ss2.deviceFactory().__name__ == "CHSesame2"
 
+    def test_CHProductModel_SS4(self):
+        ss2 = CHProductModel.SS4
+        assert ss2.deviceModel() == "sesame_4"
+        assert ss2.isLocker()
+        assert ss2.productType() == 4
+        assert ss2.deviceFactory().__name__ == "CHSesame2"
+
     def test_CHProductModel_WM2(self):
         wm2 = CHProductModel.WM2
         assert wm2.deviceModel() == "wm_2"


### PR DESCRIPTION
This PR aims to make this library support [SESAME 4](https://jp.candyhouse.co/products/sesame4).

Although [the documentation](https://doc.candyhouse.co/ja/reference) has not been updated, [the SDK has been updated](https://github.com/CANDY-HOUSE/SesameSDK_Android/commits/main). SESAME 4 can be controlled in exactly the same way as SESAME 3 in software, so we could implement it quickly.

**I hope to get feedback from users to see whether it works or not since I will not buy SESAME 4 for me.**