### PR TITLE
Set API Gateway API Key

### DIFF
--- a/pysesame3/auth.py
+++ b/pysesame3/auth.py
@@ -10,7 +10,7 @@ except ImportError:  # pragma: no cover
 import requests
 
 from .cloud import AWSIoT, SesameCloud
-from .const import CLIENT_ID, IOT_EP, AuthType
+from .const import CLIENT_ID, IOT_EP, APIGW_API_KEY, AuthType
 from .helper import RegexHelper
 
 if TYPE_CHECKING:
@@ -198,7 +198,7 @@ class CognitoAuth:
         if IOT_EP in request.url:
             service = "iotdata"
         else:
-            request.headers["x-api-key"] = self._apikey
+            request.headers["x-api-key"] = APIGW_API_KEY
             service = "execute-api"
 
         auth = AWS4Auth(

--- a/pysesame3/auth.py
+++ b/pysesame3/auth.py
@@ -10,7 +10,7 @@ except ImportError:  # pragma: no cover
 import requests
 
 from .cloud import AWSIoT, SesameCloud
-from .const import CLIENT_ID, IOT_EP, APIGW_API_KEY, AuthType
+from .const import APIGW_API_KEY, CLIENT_ID, IOT_EP, AuthType
 from .helper import RegexHelper
 
 if TYPE_CHECKING:

--- a/pysesame3/const.py
+++ b/pysesame3/const.py
@@ -2,6 +2,7 @@ from enum import Enum, IntEnum, auto
 
 OFFICIALAPI_URL = "https://app.candyhouse.co/api/sesame2"
 APIGW_URL = "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod"
+APIGW_API_KEY = "iGgXj9GorS4PeH90mAysg1l7kdvoIPxM25mPFl3k"
 IOT_EP = "a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com"
 CLIENT_ID = "ap-northeast-1:0a1820f1-dbb3-4bca-9227-2a92f6abf0ae"
 


### PR DESCRIPTION
Cognito Authを使用した際にlock, unlock, historyなどの操作を行うと403 Unauthorizedが帰ってくる。
公式SDKに元から入っているAPI KEYを使用すると動作したのでそれを使うように変更。

When using Cognito Auth, operations such as lock, unlock, history, etc., return a 403 Unauthorized.
I changed to use the API KEY that is included in the official SDK.
