### PR TITLE
Use official Web API to control SESAME devices

### DIFF
--- a/pysesame3/auth.py
+++ b/pysesame3/auth.py
@@ -70,7 +70,7 @@ class CognitoAuth:
 
         Args:
             apikey (str): API Key
-            client_id (str): Client ID
+            client_id (str): Client ID (Optional)
         """
         if len(apikey) != 40:
             raise ValueError("Invalid API Key - length should be 40.")
@@ -193,21 +193,5 @@ class CognitoAuth:
         if request.url is None:
             raise TypeError("Failed to retrive HTTP URL to send the request to.")
 
-        (access_key_id, secret_key, session_token) = self.authenticate()
-
-        if IOT_EP in request.url:
-            service = "iotdata"
-        else:
-            request.headers["x-api-key"] = self._apikey
-            service = "execute-api"
-
-        auth = AWS4Auth(
-            access_key_id,
-            secret_key,
-            RegexHelper.get_aws_region(request.url),
-            service,
-            session_token=session_token,
-        )
-        request = auth(request)
-
+        request.headers["x-api-key"] = self._apikey
         return request

--- a/pysesame3/chsesame2.py
+++ b/pysesame3/chsesame2.py
@@ -8,7 +8,7 @@ except ImportError:  # pragma: no cover
     pass
 
 from pysesame3.auth import CognitoAuth
-from pysesame3.const import CHSesame2CMD, CHSesame2ShadowStatus
+from pysesame3.const import AuthType, CHSesame2CMD, CHSesame2ShadowStatus
 from pysesame3.device import SesameLocker
 from pysesame3.helper import CHProductModel, CHSesame2MechStatus
 
@@ -94,13 +94,26 @@ class CHSesame2(SesameLocker):
             if original_status != self.getDeviceShadowStatus():
                 if self._callback is not None and callable(self._callback):
                     logger.debug(
-                        "UUID={}, Custom callback triggered".format(
+                        "UUID={}, Custom callback is triggered".format(
                             self.getDeviceUUID()
                         )
                     )
                     self._callback(self, status)
+                else:
+                    logger.debug(
+                        "UUID={}, Custom callback is not callable".format(
+                            self.getDeviceUUID()
+                        )
+                    )
+            else:
+                logger.debug(
+                    "UUID={}, Custom callback is not triggered; same getDeviceShadowStatus result".format(
+                        self.getDeviceUUID()
+                    )
+                )
         except Exception as err:  # noqa: F841
             # TODO: handle exceptions correctly
+            logger.exception(err)
             pass
 
     def subscribeMechStatus(
@@ -189,7 +202,7 @@ class CHSesame2(SesameLocker):
         result = self.authenticator.sesame_cloud.sendCmd(
             self, CHSesame2CMD.LOCK, history_tag
         )
-        if result:
+        if result and self._authenticator.login_method == AuthType.WebAPI:
             self.setDeviceShadowStatus(CHSesame2ShadowStatus.LockedWm)
         return result
 
@@ -206,7 +219,7 @@ class CHSesame2(SesameLocker):
         result = self.authenticator.sesame_cloud.sendCmd(
             self, CHSesame2CMD.UNLOCK, history_tag
         )
-        if result:
+        if result and self._authenticator.login_method == AuthType.WebAPI:
             self.setDeviceShadowStatus(CHSesame2ShadowStatus.UnlockedWm)
         return result
 

--- a/pysesame3/chsesamebot.py
+++ b/pysesame3/chsesamebot.py
@@ -96,13 +96,26 @@ class CHSesameBot(SesameLocker):
             if original_status != self.getDeviceShadowStatus():
                 if self._callback is not None and callable(self._callback):
                     logger.debug(
-                        "UUID={}, Custom callback triggered".format(
+                        "UUID={}, Custom callback is triggered".format(
                             self.getDeviceUUID()
                         )
                     )
                     self._callback(self, status)
+                else:
+                    logger.debug(
+                        "UUID={}, Custom callback is not callable".format(
+                            self.getDeviceUUID()
+                        )
+                    )
+            else:
+                logger.debug(
+                    "UUID={}, Custom callback is not triggered; same getDeviceShadowStatus result".format(
+                        self.getDeviceUUID()
+                    )
+                )
         except Exception as err:  # noqa: F841
             # TODO: handle exceptions correctly
+            logger.exception(err)
             pass
 
     def subscribeMechStatus(

--- a/pysesame3/cloud.py
+++ b/pysesame3/cloud.py
@@ -17,7 +17,7 @@ import requests
 from Crypto.Cipher import AES
 from Crypto.Hash import CMAC
 
-from .const import APIGW_URL, IOT_EP, OFFICIALAPI_URL, AuthType
+from .const import IOT_EP, OFFICIALAPI_URL
 from .history import CHSesame2History
 
 if TYPE_CHECKING:
@@ -95,18 +95,10 @@ class SesameCloud:
         Returns:
             Union[Dict, str]: Current mechanical status of the device. `Dict` if using WebAPIAuth, and `str` if using CognitoAuth.
         """
-        if self._authenticator.login_method == AuthType.WebAPI:
-            url = "{}/{}".format(OFFICIALAPI_URL, device.getDeviceUUID())
-            response = self.requestAPI("GET", url)
-            r_json = response.json()
-            return r_json
-        else:
-            url = "https://{}/things/sesame2/shadow?name={}".format(
-                IOT_EP, device.getDeviceUUID()
-            )
-            response = self.requestAPI("GET", url)
-            r_json = response.json()
-            return r_json["state"]["reported"]["mechst"]
+        url = "{}/{}".format(OFFICIALAPI_URL, device.getDeviceUUID())
+        response = self.requestAPI("GET", url)
+        r_json = response.json()
+        return r_json
 
     def sendCmd(
         self,
@@ -129,14 +121,8 @@ class SesameCloud:
                 device.getDeviceUUID(), cmd, history_tag
             )
         )
-        if self._authenticator.login_method == AuthType.WebAPI:
-            url = "{}/{}/cmd".format(OFFICIALAPI_URL, device.getDeviceUUID())
-            sign = self.getSign(device)
-        elif self._authenticator.login_method == AuthType.SDK:
-            url = "{}/device/v1/iot/sesame2/{}".format(
-                APIGW_URL, device.getDeviceUUID()
-            )
-            sign = self.getSign(device)[0:8]
+        url = "{}/{}/cmd".format(OFFICIALAPI_URL, device.getDeviceUUID())
+        sign = self.getSign(device)
 
         payload = {
             "cmd": int(cmd),
@@ -163,14 +149,9 @@ class SesameCloud:
             list[CHSesame2History]: A list of events.
         """
         logger.debug("getHistoryEntries UUID={}".format(device.getDeviceUUID()))
-        if self._authenticator.login_method == AuthType.WebAPI:
-            url = "{}/{}/history?page=0&lg=10".format(
-                OFFICIALAPI_URL, device.getDeviceUUID()
-            )
-        elif self._authenticator.login_method == AuthType.SDK:
-            url = "{}/device/v1/sesame2/{}/history?page=0&lg=10&a={}".format(
-                APIGW_URL, device.getDeviceUUID(), self.getSign(device)[0:8]
-            )
+        url = "{}/{}/history?page=0&lg=10".format(
+            OFFICIALAPI_URL, device.getDeviceUUID()
+        )
 
         ret = []
 

--- a/pysesame3/const.py
+++ b/pysesame3/const.py
@@ -1,7 +1,6 @@
 from enum import Enum, IntEnum, auto
 
 OFFICIALAPI_URL = "https://app.candyhouse.co/api/sesame2"
-APIGW_URL = "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod"
 IOT_EP = "a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com"
 CLIENT_ID = "ap-northeast-1:0a1820f1-dbb3-4bca-9227-2a92f6abf0ae"
 

--- a/tests/test_chsesame2.py
+++ b/tests/test_chsesame2.py
@@ -40,32 +40,10 @@ def mock_requests():
         )
 
         mock.get(
-            "https://a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com/things/sesame2/shadow?name=126D3D66-9222-4E5A-BCDE-0C6629D48D43",
-            json=load_fixture("lock_shadow_locked.json"),
-        )
-
-        mock.get(
-            "https://a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com/things/sesame2/shadow?name=E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1",
-            json=load_fixture("lock_shadow_unlocked.json"),
-        )
-
-        mock.post(
-            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/iot/sesame2/126D3D66-9222-4E5A-BCDE-0C6629D48D43"
-        )
-
-        mock.post(
-            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/iot/sesame2/E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1"
-        )
-
-        mock.get(
             "https://app.candyhouse.co/api/sesame2/126d3d66-9222-4e5a-bcde-0c6629d48d43/history?page=0&lg=10",
             json=load_fixture("history.json"),
         )
 
-        mock.get(
-            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/sesame2/126D3D66-9222-4E5A-BCDE-0C6629D48D43/history",
-            json=load_fixture("history.json"),
-        )
         yield mock
 
 
@@ -231,7 +209,7 @@ class TestCHSesame2Cognito:
     def test_CHSesame2(self):
         assert (
             str(self.key_locked)
-            == "CHSesame2(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=CHProductModel.SS2, mechStatus=CHSesame2MechStatus(Battery=100% (6.11V), isInLockRange=True, isInUnlockRange=False, retCode=0, target=-32768, position=29))"
+            == "CHSesame2(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=CHProductModel.SS2, mechStatus=CHSesame2MechStatus(Battery=67% (5.87V), isInLockRange=True, isInUnlockRange=False, position=11))"
         )
 
     def test_CHSesame2_iot_shadow_callback_with_missing_mechst(self):
@@ -321,7 +299,7 @@ class TestCHSesame2Cognito:
     def test_CHSesame2_lock_fails_HTTP_requests(self):
         with requests_mock.Mocker() as mock:
             mock.post(
-                "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/iot/sesame2/E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1",
+                "https://app.candyhouse.co/api/sesame2/e0e56521-63d8-4da5-ba4b-c4a6a5e353f1/cmd",
                 status_code=500,
             )
             assert not self.key_unlocked.lock()
@@ -330,29 +308,27 @@ class TestCHSesame2Cognito:
                 == CHSesame2ShadowStatus.UnlockedWm
             )
 
-    def test_CHSesame2_lock(self):
+    def test_CHSesame2_lock_but_keep_state(self):
         assert self.key_unlocked.lock()
         assert (
-            self.key_unlocked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
+            self.key_unlocked.getDeviceShadowStatus()
+            == CHSesame2ShadowStatus.UnlockedWm
         )
 
-    def test_CHSesame2_unlock(self):
+    def test_CHSesame2_unlock_but_keep_state(self):
         assert self.key_locked.unlock()
-        assert (
-            self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.UnlockedWm
-        )
+        assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
 
-    def test_CHSesame2_toggle(self):
+    def test_CHSesame2_toggle_but_keep_state(self):
         assert self.key_locked.toggle()
-        assert (
-            self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.UnlockedWm
-        )
+        assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
         assert self.key_locked.toggle()
         assert self.key_locked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
 
         assert self.key_unlocked.toggle()
         assert (
-            self.key_unlocked.getDeviceShadowStatus() == CHSesame2ShadowStatus.LockedWm
+            self.key_unlocked.getDeviceShadowStatus()
+            == CHSesame2ShadowStatus.UnlockedWm
         )
         assert self.key_unlocked.toggle()
         assert (

--- a/tests/test_chsesamebot.py
+++ b/tests/test_chsesamebot.py
@@ -41,32 +41,10 @@ def mock_requests():
         )
 
         mock.get(
-            "https://a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com/things/sesame2/shadow?name=126D3D66-9222-4E5A-BCDE-0C6629D48D43",
-            json=load_fixture("button_shadow_locked.json"),
-        )
-
-        mock.get(
-            "https://a3i4hui4gxwoo8-ats.iot.ap-northeast-1.amazonaws.com/things/sesame2/shadow?name=E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1",
-            json=load_fixture("button_shadow_unlocked.json"),
-        )
-
-        mock.post(
-            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/iot/sesame2/126D3D66-9222-4E5A-BCDE-0C6629D48D43"
-        )
-
-        mock.post(
-            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/iot/sesame2/E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1"
-        )
-
-        mock.get(
             "https://app.candyhouse.co/api/sesame2/126d3d66-9222-4e5a-bcde-0c6629d48d43/history?page=0&lg=10",
             json=load_fixture("history.json"),
         )
 
-        mock.get(
-            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/sesame2/126D3D66-9222-4E5A-BCDE-0C6629D48D43/history",
-            json=load_fixture("history.json"),
-        )
         yield mock
 
 
@@ -196,7 +174,7 @@ class TestCHSesameBotCognito:
     def test_CHSesameBot(self):
         assert (
             str(self.key_locked)
-            == "CHSesameBot(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=CHProductModel.SesameBot1, mechStatus=CHSesameBotMechStatus(Battery=100% (3.00V), motorStatus=0))"
+            == "CHSesameBot(deviceUUID=126D3D66-9222-4E5A-BCDE-0C6629D48D43, deviceModel=CHProductModel.SesameBot1, mechStatus=CHSesameBotMechStatus(Battery=100% (6.00V), motorStatus=0))"
         )
 
     def test_CHSesameBot_iot_shadow_callback_with_missing_mechst(self):
@@ -284,13 +262,13 @@ class TestCHSesameBotCognito:
     def test_CHSesameBot_click_fails_HTTP_requests(self):
         with requests_mock.Mocker() as mock:
             mock.post(
-                "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/iot/sesame2/E0E56521-63D8-4DA5-BA4B-C4A6A5E353F1",
+                "https://app.candyhouse.co/api/sesame2/126d3d66-9222-4e5a-bcde-0c6629d48d43/cmd",
                 status_code=500,
             )
-            assert not self.key_unlocked.click()
+            assert not self.key_locked.click()
             assert (
-                self.key_unlocked.getDeviceShadowStatus()
-                == CHSesame2ShadowStatus.UnlockedWm
+                self.key_locked.getDeviceShadowStatus()
+                == CHSesame2ShadowStatus.LockedWm
             )
 
     def test_CHSesameBot_click(self):

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -29,11 +29,6 @@ def mock_requests():
             "https://app.candyhouse.co/api/sesame2/FAKEUUID/history?page=0&lg=10",
             json=load_fixture("history.json"),
         )
-
-        mock.get(
-            "https://jhcr1i3ecb.execute-api.ap-northeast-1.amazonaws.com/prod/device/v1/sesame2/FAKEUUID/history",
-            json=load_fixture("history.json"),
-        )
         yield mock
 
 


### PR DESCRIPTION
I don't think I have received any official notification yet, but it seems that users are now charged to use the Web API from Candyhouse as pointed at https://github.com/mochipon/pysesame3/pull/79?w=1#issuecomment-1135619952 (comment).

We are now at a crossroads in the future direction of this project. and I hope that this project will not be harmful to everyone includes Candyhouse. Therefore, I have decided to remove some of the features already implemented.

That is, we choose to use only the official (i.e., paid) Web API to operate the device.

However, there is one critical feature missing here. We cannot get real-time notifications of status changes. We all know that Candyhouse has promised to provide some features (e.g., Webhook, IFTTT), but that promise has not been delivered for a long time. Therefore, this library will continue to provide the ability to connect to AWS IoT Core and receive real-time device state changes. This is the only feature that this library implements that is not officially provided.